### PR TITLE
fix the stragegy name of suomi.fi saml auth

### DIFF
--- a/api-gateway/src/router.ts
+++ b/api-gateway/src/router.ts
@@ -55,13 +55,13 @@ export function createRouter(config: Config, redisClient: RedisClient): Router {
       '/auth/saml-suomifi',
       createSamlRouter({
         sessions,
-        strategyName: 'ead',
+        strategyName: 'suomifi',
         strategy: createSuomiFiStrategy(
           sessions,
           createSamlConfig(
             config.sfi.saml,
             redisCacheProvider(redisClient, {
-              keyPrefix: 'ad-saml-suomifi-resp:'
+              keyPrefix: 'suomifi-saml-resp:'
             })
           )
         )


### PR DESCRIPTION
The two SAML auth strategies (ad and suomi.fi) both used the same name (`ead`). This might cause that suomi.fi isn't configured correctly.