### PR TITLE
add correct reservation periods to the database

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/domain/ReservationPeriod.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/domain/ReservationPeriod.kt
@@ -1,7 +1,9 @@
 package fi.espoo.vekkuli.domain
 
 data class ReservationPeriod(
-    val id: String,
+    val isEspooCitizen: Boolean,
+    val operation: ReservationOperation,
+    val boatSpaceType: BoatSpaceType,
     val startMonth: Int,
     val startDay: Int,
     val endMonth: Int,

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/BoatSpaceReservationRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/BoatSpaceReservationRepository.kt
@@ -60,5 +60,9 @@ interface BoatSpaceReservationRepository {
 
     fun terminateBoatSpaceReservation(reservationId: Int): BoatSpaceReservation
 
-    fun getReservationPeriods(): List<ReservationPeriod>
+    fun getReservationPeriods(
+        isEspooCitizen: Boolean,
+        boatSpaceType: BoatSpaceType,
+        operation: ReservationOperation
+    ): List<ReservationPeriod>
 }

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceReservationRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceReservationRepository.kt
@@ -598,16 +598,25 @@ class JdbiBoatSpaceReservationRepository(
             query.mapTo<BoatSpaceReservation>().one()
         }
 
-    override fun getReservationPeriods(): List<ReservationPeriod> =
+    override fun getReservationPeriods(
+        isEspooCitizen: Boolean,
+        boatSpaceType: BoatSpaceType,
+        operation: ReservationOperation
+    ): List<ReservationPeriod> =
         jdbi.withHandleUnchecked { handle ->
-            handle
-                .createQuery(
+            val query =
+                handle.createQuery(
                     """
                     SELECT *
                     FROM reservation_period
-                    ORDER BY match_order ASC
+                    WHERE is_espoo_citizen = :isEspooCitizen
+                        AND operation = :operation
+                        AND boat_space_type = :boatSpaceType
                     """.trimIndent()
-                ).mapTo<ReservationPeriod>()
-                .list()
+                )
+            query.bind("isEspooCitizen", isEspooCitizen)
+            query.bind("operation", operation)
+            query.bind("boatSpaceType", boatSpaceType)
+            query.mapTo<ReservationPeriod>().list()
         }
 }

--- a/service/src/main/resources/db/migration/V028__change_reservation_periods.sql
+++ b/service/src/main/resources/db/migration/V028__change_reservation_periods.sql
@@ -1,0 +1,35 @@
+DELETE FROM reservation_period;
+
+ALTER TABLE reservation_period
+    DROP COLUMN id,
+    ADD COLUMN is_espoo_citizen BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN operation ReservationOperation NOT NULL DEFAULT 'New',
+    ADD COLUMN boat_space_type BoatSpaceType NOT NULL DEFAULT 'Slip';
+
+INSERT INTO reservation_period(is_espoo_citizen, boat_space_type, operation, start_month, start_day, end_month, end_day)
+VALUES
+    -- For Espoo citizens
+    (true, 'Slip', 'New', 3, 1, 9, 30),
+    (true, 'Slip', 'Renew', 1, 7, 1, 31),
+    (true, 'Slip', 'Change', 1, 7, 1, 31),
+    (true, 'Slip', 'Change', 3, 1, 9, 30),
+    (true, 'Trailer', 'New', 5, 1, 12, 31),
+    (true, 'Trailer', 'Renew', 4, 1, 4, 30),
+    (true, 'Trailer', 'Change',  4, 1, 12, 31),
+    (true, 'Winter', 'New', 9, 1, 12, 31),
+    (true, 'Winter', 'Renew',  8, 1, 8, 31),
+    (true, 'Winter', 'Change',  8, 1, 12, 31),
+    (true, 'Storage', 'New', 9, 1, 31, 7),
+    (true, 'Storage', 'Renew',  8, 1, 8, 31),
+    (true, 'Storage', 'Change',  8, 1, 7, 31),
+
+    -- For non-Espoo citizens
+    (false, 'Slip', 'New', 4, 1, 9, 30),
+    (false, 'Slip', 'Change', 4, 1, 9, 30),
+    (false, 'Trailer', 'New', 5, 1, 12, 31),
+    (false, 'Trailer', 'Change',  5, 1, 12, 31),
+    (false, 'Winter', 'New', 9, 15, 12, 31),
+    (false, 'Winter', 'Change',  9, 15, 12, 31),
+    (false, 'Storage', 'New', 9, 15, 7, 31),
+    (false, 'Storage', 'Renew', 9, 1, 9, 15),
+    (false, 'Storage', 'Change',  9, 1, 7, 31);


### PR DESCRIPTION
Add three new columns to reservation_period table: is_espoo_citizen, boat_space_type  and operation. This three fields affect, which reservation period is active at certain time.

`hasActiveReservationPeriod`-function can be used to check if certain reservation operation can be done at current time.