### PR TITLE
Add new Variable table and service, change staging & local TimeProvider

### DIFF
--- a/service/src/e2eTest/resources/seed.sql
+++ b/service/src/e2eTest/resources/seed.sql
@@ -2999,10 +2999,14 @@ INSERT INTO boat_space (id, type, location_id, price_id, section, place_number, 
     ('2435', 'Slip', '7', '4', 'E', '66', 'WalkBeam', '380', '1000', 'none'),
     ('2436', 'Slip', '7', '3', 'E', '68', 'WalkBeam', '320', '1000', 'none');
 
-/* System current date for tests 01-04-2024 */
+/* System current date for tests 2024-04-01 */
 INSERT INTO boat_space_reservation (reserver_id, boat_space_id, start_date, end_date,  status, boat_id)
 VALUES ('f5d377ea-5547-11ef-a1c7-7f2b94cf9afd', 1,'2024-02-01', '2025-01-31', 'Confirmed', 1),
        ('509edb00-5549-11ef-a1c7-776e76028a49', 2, '2024-02-01', '2025-01-31', 'Confirmed', 2),
        ('509edb00-5549-11ef-a1c7-776e76028a49', 2, '2023-02-01', '2024-01-31', 'Invoiced', 2),
        ('509edb00-5549-11ef-a1c7-776e76028a49', 2, '2022-02-01', '2023-01-31', 'Confirmed', 2),
        ('509edb00-5549-11ef-a1c7-776e76028a49', 2, '2021-02-01', '2022-01-31', 'Payment', 2);
+
+-- Set the default staging system date to 2024-04-01
+INSERT INTO variable (id, value)
+VALUES ('current_system_staging_datetime', '2024-04-01T00:00:00');

--- a/service/src/main/kotlin/fi/espoo/vekkuli/controllers/admin/SystemDateTimeController.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/controllers/admin/SystemDateTimeController.kt
@@ -1,0 +1,57 @@
+package fi.espoo.vekkuli.controllers.admin
+
+import fi.espoo.vekkuli.service.VariableService
+import fi.espoo.vekkuli.utils.TimeProvider
+import fi.espoo.vekkuli.views.admin.Layout
+import fi.espoo.vekkuli.views.admin.SetCurrentSystemTime
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@RestController
+@RequestMapping("/admin")
+class SystemDateTimeController(
+    private val variable: VariableService,
+    private val adminLayout: Layout,
+    private val timeProvider: TimeProvider,
+    private val setCurrentSystemTime: SetCurrentSystemTime
+) {
+    @PostMapping("/set-system-date")
+    fun setSystemDate(
+        request: HttpServletRequest,
+        @RequestParam newSystemDate: LocalDate?,
+    ): ResponseEntity<Void> {
+        val variableId = "current_system_staging_datetime"
+        if (newSystemDate == null) {
+            variable.delete(variableId)
+        } else {
+            val dateTime: LocalDateTime = newSystemDate.atTime(LocalTime.of(0, 0, 0))
+            variable.set(variableId, dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+        }
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/get-system-date")
+    fun getSystemDate(request: HttpServletRequest): ResponseEntity<String> =
+        ResponseEntity.ok(
+            timeProvider.getCurrentDateTime().format(DateTimeFormatter.ISO_DATE_TIME)
+        )
+
+    @GetMapping("/set-system-date")
+    @ResponseBody
+    fun setSystemDateView(request: HttpServletRequest) =
+        ResponseEntity
+            .ok()
+            .header("Content-Type", "text/html")
+            .body(
+                adminLayout.render(
+                    setCurrentSystemTime.render(
+                        timeProvider.getCurrentDateTime()
+                    )
+                )
+            )
+}

--- a/service/src/main/kotlin/fi/espoo/vekkuli/domain/Variable.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/domain/Variable.kt
@@ -1,0 +1,6 @@
+package fi.espoo.vekkuli.domain
+
+data class Variable(
+    val id: String,
+    val value: String,
+)

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiVariableRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiVariableRepository.kt
@@ -1,0 +1,59 @@
+package fi.espoo.vekkuli.repository
+
+import fi.espoo.vekkuli.domain.*
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.mapTo
+import org.jdbi.v3.core.kotlin.withHandleUnchecked
+import org.springframework.stereotype.Repository
+
+@Repository
+class JdbiVariableRepository(
+    private val jdbi: Jdbi
+) : VariableRepository {
+    override fun setVariable(
+        id: String,
+        value: String
+    ): Variable =
+        jdbi.withHandleUnchecked { handle ->
+            val result =
+                handle
+                    .createQuery(
+                        """
+                        INSERT INTO variable (id, value)
+                        VALUES (:id, :value)
+                        ON CONFLICT (id) 
+                        DO UPDATE SET value = EXCLUDED.value
+                        RETURNING *
+                        """
+                    ).bind("id", id)
+                    .bind("value", value)
+                    .mapTo<Variable>()
+                    .one()
+            result
+        }
+
+    override fun getVariable(id: String): Variable? =
+        jdbi.withHandleUnchecked { handle ->
+            handle
+                .createQuery(
+                    """
+                    SELECT * FROM variable WHERE id = :id
+                    """.trimIndent()
+                ).bind("id", id)
+                .mapTo<Variable>()
+                .firstOrNull()
+        }
+
+    override fun deleteVariable(id: String): Boolean =
+        jdbi.withHandleUnchecked { handle ->
+            val rowsAffected =
+                handle
+                    .createUpdate(
+                        """
+                        DELETE FROM variable WHERE id = :id
+                        """.trimIndent()
+                    ).bind("id", id)
+                    .execute()
+            rowsAffected > 0
+        }
+}

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/VariableRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/VariableRepository.kt
@@ -1,0 +1,14 @@
+package fi.espoo.vekkuli.repository
+
+import fi.espoo.vekkuli.domain.Variable
+
+interface VariableRepository {
+    fun getVariable(id: String): Variable?
+
+    fun setVariable(
+        id: String,
+        value: String
+    ): Variable
+
+    fun deleteVariable(id: String): Boolean
+}

--- a/service/src/main/kotlin/fi/espoo/vekkuli/service/VariableService.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/service/VariableService.kt
@@ -1,0 +1,19 @@
+package fi.espoo.vekkuli.service
+
+import fi.espoo.vekkuli.domain.Variable
+import fi.espoo.vekkuli.repository.VariableRepository
+import org.springframework.stereotype.Service
+
+@Service
+class VariableService(
+    private val variableRepository: VariableRepository
+) {
+    fun set(
+        id: String,
+        value: String
+    ): Variable = variableRepository.setVariable(id, value)
+
+    fun get(id: String): Variable? = variableRepository.getVariable(id)
+
+    fun delete(id: String): Boolean = variableRepository.deleteVariable(id)
+}

--- a/service/src/main/kotlin/fi/espoo/vekkuli/views/admin/Layout.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/views/admin/Layout.kt
@@ -1,0 +1,23 @@
+package fi.espoo.vekkuli.views.admin
+
+import fi.espoo.vekkuli.views.head
+import org.springframework.stereotype.Service
+
+@Service("AdminLayout")
+class Layout {
+    fun render(bodyContent: String): String {
+        // language=HTML
+        return """
+            <!DOCTYPE html>
+            <html class="theme-light">
+                <head>
+                    <title>Admin</title>
+                    $head
+                </head>
+                <body>
+                    $bodyContent     
+                </body>
+            </html>
+            """.trimIndent()
+    }
+}

--- a/service/src/main/kotlin/fi/espoo/vekkuli/views/admin/SetCurrentSystemTime.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/views/admin/SetCurrentSystemTime.kt
@@ -1,0 +1,41 @@
+package fi.espoo.vekkuli.views.admin
+
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Service
+class SetCurrentSystemTime {
+    fun render(time: LocalDateTime): String {
+        // language=HTML
+        return """
+            <section class="section">
+                <div class="container">
+                    <h2>Current Staging time: ${time.format(DateTimeFormatter.ofPattern("dd.MM.yyyy, HH:mm:ss"))}</h2>
+                    <form id="set-staging-form"
+                      class="is-inline-block"
+                      method="post" 
+                      hx-post="/admin/set-system-date"
+                      hx-on-htmx-after-request="window.location.reload()"
+                    >
+                         <div class="field">
+                            <div class="control">
+                                <label class="label" for="newSystemDate" >Set system date</label>
+                                <input
+                                    class="input"
+                                    type="date"
+                                    id="newSystemDate"
+                                    name="newSystemDate"
+                                    ${if (time != null) "value=\"${time.format(DateTimeFormatter.ISO_DATE)}\"" else ""}
+                                   />
+                            </div>
+                        </div>
+                        <buttons>
+                            <button type="submit" class="button is-primary">Set system date</button>
+                       </buttons>
+                    </form>
+                </div>
+            </section>
+            """.trimIndent()
+    }
+}

--- a/service/src/main/resources/db/migration/V033__add_variable_table.sql
+++ b/service/src/main/resources/db/migration/V033__add_variable_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE variable (
+     id VARCHAR(128) PRIMARY KEY,
+     value TEXT NOT NULL
+);


### PR DESCRIPTION
Add new variable table and related VariableService and VariableRepository.
Allows setting key value pairs to db.
Use that to save the current system time for local & staging testing purposes
Added admin route for setting and checking current time
/admin/set-system-time