### PR TITLE
Fix reservation person name order

### DIFF
--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveBoatSpaceAsEmployeeTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveBoatSpaceAsEmployeeTest.kt
@@ -146,7 +146,7 @@ class ReserveBoatSpaceAsEmployeeTest : PlaywrightTest() {
 
             val reservationListPage = ReservationListPage(page)
             assertThat(reservationListPage.header).isVisible()
-            page.getByText("John Doe").click()
+            page.getByText("Doe John").click()
             val citizenDetailsPage = CitizenDetailsPage(page)
             citizenDetailsPage.invoicePaidButton.click()
             val info = "invoice has been paid"

--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/CitizenServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/CitizenServiceIntegrationTests.kt
@@ -28,14 +28,7 @@ class CitizenServiceIntegrationTests : IntegrationTestBase() {
 
     @Test
     fun `should get citizen by full name`() {
-        val citizens = citizenService.getCitizens("Olivia Virtanen")
-        assertEquals(1, citizens.size, "Should find a citizen")
-        assertEquals(citizenIdOlivia, citizens[0].id, "Citizen is correctly fetched")
-    }
-
-    @Test
-    fun `should get citizen by first name`() {
-        val citizens = citizenService.getCitizens("olivia")
+        val citizens = citizenService.getCitizens("Virtanen Olivia")
         assertEquals(1, citizens.size, "Should find a citizen")
         assertEquals(citizenIdOlivia, citizens[0].id, "Citizen is correctly fetched")
     }

--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReservationServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReservationServiceIntegrationTests.kt
@@ -388,7 +388,7 @@ class ReservationServiceIntegrationTests : IntegrationTestBase() {
             )
 
         assertEquals(1, reservationsByFirstName.size, "reservations are filtered correctly")
-        assertEquals("Leo Korhonen", reservationsByFirstName.first().name, "correct reservation is returned")
+        assertEquals("Korhonen Leo", reservationsByFirstName.first().name, "correct reservation is returned")
 
         val reservationsByLastName =
             reservationService.getBoatSpaceReservations(
@@ -399,8 +399,8 @@ class ReservationServiceIntegrationTests : IntegrationTestBase() {
 
         assertEquals(2, reservationsByLastName.size, "reservations are filtered correctly")
         val reservationsNames = reservationsByLastName.map { "${it.name}" }
-        assertContains(reservationsNames, "Mikko Virtanen")
-        assertContains(reservationsNames, "Olivia Virtanen")
+        assertContains(reservationsNames, "Virtanen Mikko")
+        assertContains(reservationsNames, "Virtanen Olivia")
     }
 
     @Test

--- a/service/src/main/resources/db/migration/V042__fix_reserver_name.sql
+++ b/service/src/main/resources/db/migration/V042__fix_reserver_name.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION update_reserver_name()
+    RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE reserver
+    SET name = NEW.last_name || ' ' || NEW.first_name
+    WHERE id = NEW.id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
- Reserver Firstname Lastname -> Lastname Firstname
- After this fix is in an environment all the citizens' first_name or last_name field must be set again for this trigger to reflect the change on the reservations

