### PR TITLE
load the available spaces when input changes

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/views/citizen/BoatSpaceSearch.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/views/citizen/BoatSpaceSearch.kt
@@ -119,7 +119,7 @@ class BoatSpaceSearch(
                                   hx-get="$url"
                                   hx-target="#boatSpaces"
                                   hx-swap="innerHTML"
-                                  hx-trigger="change, load, input changed delay:1000ms"
+                                  hx-trigger="change, load, input changed delay:300ms, keyup delay:300ms"
                                   hx-sync="closest #form:replace"
                                   hx-indicator="#loader, .loaded-content"
                                   >


### PR DESCRIPTION
Use also `keyup` event, because `input` event is only triggered when moving out of input element. Use 300ms debounce so that not each keypress triggers the loading.