### PR TITLE
hide new boat selection

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/views/citizen/BoatSpaceForm.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/views/citizen/BoatSpaceForm.kt
@@ -85,7 +85,7 @@ class BoatSpaceForm(
 
         // language=HTML
         val chooseBoatButtons =
-            if (citizen !== null) {
+            if (citizen !== null && boats.isNotEmpty()) {
                 """
             <div id="boatOptions" class="field" x-data="{ initialWidth: localStorage.getItem('width'), 
                                          initialLength: localStorage.getItem('length'), 


### PR DESCRIPTION
When use doesn't have any boats we can hide the boat selection option buttons. In this case the boat is always new boat.