### PR TITLE
prevent duplicate payments for reservation

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiPaymentRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiPaymentRepository.kt
@@ -116,7 +116,7 @@ class JdbiPaymentRepository(
                 .firstOrNull()
         }
 
-    override fun deletePaymentInCreateStatusForReservation(reservationId: Int) {
+    override fun deletePaymentInCreatedStatusForReservation(reservationId: Int) {
         jdbi.withHandleUnchecked { handle ->
             handle
                 .createUpdate(

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/PaymentRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/PaymentRepository.kt
@@ -10,7 +10,7 @@ import java.util.*
 interface PaymentRepository {
     fun getPayment(stamp: UUID): Payment?
 
-    fun deletePaymentInCreateStatusForReservation(reservationId: Int): Unit
+    fun deletePaymentInCreatedStatusForReservation(reservationId: Int): Unit
 
     fun insertPayment(
         params: CreatePaymentParams,

--- a/service/src/main/kotlin/fi/espoo/vekkuli/service/BoatReservationService.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/service/BoatReservationService.kt
@@ -195,7 +195,7 @@ class BoatReservationService(
         reservationId: Int,
         params: CreatePaymentParams
     ): Payment {
-        paymentService.deletePaymentInCreateStatusForReservation(reservationId)
+        paymentService.deletePaymentInCreatedStatusForReservation(reservationId)
         return paymentService.insertPayment(params, reservationId)
     }
 

--- a/service/src/main/kotlin/fi/espoo/vekkuli/service/PaymentService.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/service/PaymentService.kt
@@ -15,8 +15,8 @@ class PaymentService(
 ) {
     fun getPayment(stamp: UUID): Payment? = paymentRepo.getPayment(stamp)
 
-    fun deletePaymentInCreateStatusForReservation(reservationId: Int) {
-        paymentRepo.deletePaymentInCreateStatusForReservation(reservationId)
+    fun deletePaymentInCreatedStatusForReservation(reservationId: Int) {
+        paymentRepo.deletePaymentInCreatedStatusForReservation(reservationId)
     }
 
     fun updatePayment(


### PR DESCRIPTION
When loading the payment page, remove any existing payment row for reservation before creating a new row.