### PR TITLE
Make async jobs more tolerant to time machine

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/asyncJob/AsyncJobRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/asyncJob/AsyncJobRepository.kt
@@ -202,7 +202,7 @@ WHERE id = :jobId
         val toMillis =
             Duration
                 .between(
-                    timeProvider.getCurrentDateTime().toInstant(ZoneOffset.UTC),
+                    Instant.now(),
                     permit.availableAt
                 ).toMillis()
         if (toMillis > 0) {
@@ -212,7 +212,7 @@ WHERE id = :jobId
             )
         }
         return claimJob(timeProvider.getCurrentDateTime().toInstant(ZoneOffset.UTC), pool.registration.jobTypes())?.also {
-            updatePermit(pool.id, timeProvider.getCurrentDateTime().toInstant(ZoneOffset.UTC).plus(pool.throttleInterval))
+            updatePermit(pool.id, Instant.now().plus(pool.throttleInterval))
         }
     }
 

--- a/service/src/main/kotlin/fi/espoo/vekkuli/config/AsyncJobConfig.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/config/AsyncJobConfig.kt
@@ -5,7 +5,6 @@
 package fi.espoo.vekkuli.config
 
 import fi.espoo.vekkuli.asyncJob.*
-import fi.espoo.vekkuli.utils.TimeProvider
 import mu.KotlinLogging
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
@@ -15,10 +14,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class AsyncJobConfig {
     @Bean
-    fun asyncJobRunner(
-        repository: IAsyncJobRepository,
-        timeProvider: TimeProvider
-    ): IAsyncJobRunner<AsyncJob> =
+    fun asyncJobRunner(repository: IAsyncJobRepository): IAsyncJobRunner<AsyncJob> =
         AsyncJobRunner(
             AsyncJob::class,
             listOf(
@@ -30,8 +26,7 @@ class AsyncJobConfig {
                     ),
                 )
             ),
-            repository,
-            timeProvider
+            repository
         )
 
     @Bean


### PR DESCRIPTION
When using the time machine to change the apparent datetime async jobs get easily stuck. For example if a job is waiting until time X, and then time changes, the wait can be months. Here we use the real time when calculating the wait between retries etc.