### PR TITLE
Fix some of citizen details related E2E tests

### DIFF
--- a/api-gateway/src/auth/dev-ad-auth.ts
+++ b/api-gateway/src/auth/dev-ad-auth.ts
@@ -45,6 +45,7 @@ const loginFormHandler: AsyncRequestHandler = async (req, res) => {
             <input
               type="radio"
               id="${externalId}"
+              data-testid="${externalId}"
               name="preset"
               ${idx == 0 ? 'checked' : ''}
               value="${_.escape(json)}" />

--- a/api-gateway/src/auth/dev-sfi-auth.ts
+++ b/api-gateway/src/auth/dev-sfi-auth.ts
@@ -76,6 +76,7 @@ const loginFormHandler: AsyncRequestHandler = async (req, res) => {
             <input
               type="radio"
               id="${nationalId}"
+              data-testid="${nationalId}"
               name="preset"
               ${idx == 0 ? 'checked' : ''}
               value="${_.escape(json)}" />

--- a/frontend/src/citizen-frontend/citizen/sections/boats/Boat.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/boats/Boat.tsx
@@ -50,7 +50,7 @@ export default React.memo(function Boat({ boat }: { boat: Boat }) {
   } = useFormFields(bind)
 
   return (
-    <div className="reservation-card">
+    <div className="reservation-card" data-testid={`boat-${boat.id}`}>
       <Columns isVCentered>
         <Column isNarrow>
           <h4>{boat.name}</h4>
@@ -102,6 +102,7 @@ export default React.memo(function Boat({ boat }: { boat: Boat }) {
             bind={depth}
             required={editMode}
             readonly={!editMode}
+            precision={2}
           />
           <TextField
             label="Lisätiedot"
@@ -117,6 +118,7 @@ export default React.memo(function Boat({ boat }: { boat: Boat }) {
             bind={width}
             required={editMode}
             readonly={!editMode}
+            precision={2}
           />
           <TextField
             label="Rekisteritunnus"
@@ -126,12 +128,13 @@ export default React.memo(function Boat({ boat }: { boat: Boat }) {
           />
         </Column>
         <Column>
-          <TextField
+          <NumberField
             label="Pituus (m)"
             name="length"
             bind={length}
             required={editMode}
             readonly={!editMode}
+            precision={2}
           />
           <SelectField
             label="Omistussuhde"

--- a/frontend/src/citizen-frontend/citizen/sections/citizenInformation/CitizenInformation.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/citizenInformation/CitizenInformation.tsx
@@ -46,7 +46,7 @@ export default React.memo(function CitizenInformation({
 
   const { phone, email } = useFormFields(form)
   return (
-    <Container isBlock>
+    <Container isBlock data-testid="citizen-information">
       <FormSection>
         <Columns>
           <Column>

--- a/frontend/src/citizen-frontend/citizen/sections/citizenInformation/formDefinitions.ts
+++ b/frontend/src/citizen-frontend/citizen/sections/citizenInformation/formDefinitions.ts
@@ -1,11 +1,12 @@
 import { User } from 'citizen-frontend/auth/state'
 import { string } from 'lib-common/form/fields'
-import { object, required } from 'lib-common/form/form'
+import { object, required, validated } from 'lib-common/form/form'
+import { email, phone } from 'lib-common/form/form-validation'
 import { StateOf } from 'lib-common/form/types'
 
 export const citizenInformationForm = object({
-  email: required(string()),
-  phone: required(string())
+  email: validated(required(string()), email),
+  phone: validated(required(string()), phone)
 })
 export type CitizenInformationForm = typeof citizenInformationForm
 

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/ExpiredReservations.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/ExpiredReservations.tsx
@@ -16,7 +16,10 @@ export default React.memo(function ExpiredReservations({
   return (
     <Container isBlock>
       <h3>Päättyneet</h3>
-      <div className="reservation-list form-section">
+      <div
+        className="reservation-list form-section"
+        data-testid="expired-reservation-list"
+      >
         <Accordion title="Päättyneet varaukset">
           {reservations.map((reservation) => (
             <Reservation

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/Reservation.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/Reservation.tsx
@@ -42,7 +42,7 @@ export default React.memo(function Reservation({
   }
   return (
     <>
-      <div className="reservation-card">
+      <div className="reservation-card" data-testid="reservation-list-card">
         <Columns isVCentered>
           <Column isNarrow>
             <h4>
@@ -64,8 +64,9 @@ export default React.memo(function Reservation({
             />
             <NumberField
               label="Leveys (m)"
-              value={formatNumber(boatSpace.width)}
+              value={formatNumber(boatSpace.width, 2)}
               readonly={true}
+              precision={2}
             />
             <TextField
               label="Varaus tehty"
@@ -84,8 +85,9 @@ export default React.memo(function Reservation({
             />
             <NumberField
               label="Pituus (m)"
-              value={formatNumber(boatSpace.length)}
+              value={formatNumber(boatSpace.length, 2)}
               readonly={true}
+              precision={2}
             />
             <TextField
               label="Varaus voimassa"

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/Reservations.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/Reservations.tsx
@@ -13,7 +13,7 @@ export default React.memo(function Reservations({
   if (!reservations.length) return null
 
   return (
-    <Container isBlock>
+    <Container isBlock data-testid="reservation-list">
       <h3>Paikkavaraukset</h3>
       <div className="reservation-list form-section">
         {reservations.map((reservation) => (

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModal.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModal.tsx
@@ -47,24 +47,27 @@ export default React.memo(function TerminateModal({
       title="Olet irtisanomassa venepaikkaa:"
       close={close}
       buttons={buttons}
+      data-testid="terminate-reservation-modal"
     >
       <Columns isMultiline>
         <Column isFull>
           <ul className="no-bullets">
-            <li>
+            <li data-testid="place-identifier">
               {formatPlaceIdentifier(
                 reservation.boatSpace.section,
                 reservation.boatSpace.placeNumber,
                 reservation.boatSpace.locationName
               )}
             </li>
-            <li>
+            <li data-testid="boat-space">
               {formatDimensions({
                 width: reservation.boatSpace.width,
                 length: reservation.boatSpace.length
               })}
             </li>
-            <li>{i18n.boatSpace.amenities[reservation.boatSpace.amenity]}</li>
+            <li data-testid="amenity">
+              {i18n.boatSpace.amenities[reservation.boatSpace.amenity]}
+            </li>
           </ul>
         </Column>
         <Column isFull>

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModalFailure.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModalFailure.tsx
@@ -19,7 +19,12 @@ export default React.memo(function TerminateModalFailure({
   ]
 
   return (
-    <Modal close={close} buttons={buttons} buttonsCentered>
+    <Modal
+      close={close}
+      buttons={buttons}
+      buttonsCentered
+      data-testid="terminate-reservation-failure-modal"
+    >
       <Columns isVCentered isMultiline>
         <Column isFull textCentered>
           <Failure />

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModalSuccess.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/TerminateModalSuccess.tsx
@@ -13,7 +13,7 @@ export default React.memo(function TerminateModalSuccess({
 }: TerminateModalProps) {
   setTimeout(() => close(), 3000)
   return (
-    <Modal close={close}>
+    <Modal close={close} data-testid="terminate-reservation-success-modal">
       <Columns isVCentered isMultiline>
         <Column isFull textCentered>
           <Success />

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/TrailerInformation.tsx
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/TrailerInformation.tsx
@@ -47,7 +47,7 @@ export default React.memo(function TrailerInformation({
 
   const { registrationNumber, length, width } = useFormFields(form)
   return (
-    <>
+    <div data-testid="trailer-information">
       <Columns isVCentered>
         <Column isNarrow>
           <h4>Trailerin tiedot</h4>
@@ -69,10 +69,20 @@ export default React.memo(function TrailerInformation({
           />
         </Column>
         <Column isOneQuarter>
-          <NumberField label="Leveys (m)" bind={width} readonly={!editMode} />
+          <NumberField
+            label="Leveys (m)"
+            bind={width}
+            readonly={!editMode}
+            precision={2}
+          />
         </Column>
         <Column isOneQuarter>
-          <NumberField label="Pituus (m)" bind={length} readonly={!editMode} />
+          <NumberField
+            label="Pituus (m)"
+            bind={length}
+            readonly={!editMode}
+            precision={2}
+          />
         </Column>
       </Columns>
       {editMode && (
@@ -85,6 +95,6 @@ export default React.memo(function TrailerInformation({
           </Button>
         </Buttons>
       )}
-    </>
+    </div>
   )
 })

--- a/frontend/src/citizen-frontend/citizen/sections/reservations/queries.ts
+++ b/frontend/src/citizen-frontend/citizen/sections/reservations/queries.ts
@@ -5,5 +5,8 @@ import { queryKeys } from '../../queries'
 
 export const terminateReservationMutation = mutation({
   api: terminateReservation,
-  invalidateQueryKeys: () => [queryKeys.citizenActiveReservations()]
+  invalidateQueryKeys: () => [
+    queryKeys.citizenActiveReservations(),
+    queryKeys.citizenExpiredReservations()
+  ]
 })

--- a/frontend/src/citizen-frontend/layout/LanguageSelection.tsx
+++ b/frontend/src/citizen-frontend/layout/LanguageSelection.tsx
@@ -8,7 +8,7 @@ export default React.memo(function LanguageSelection() {
   const i18n = useTranslation()
   const [lang, setLang] = useLang()
   return (
-    <div className="dropdown is-hoverable" id="language-selection">
+    <div className="dropdown is-hoverable" data-testid="language-selection">
       <div className="dropdown-trigger">
         <a
           className="dropdown-title"

--- a/frontend/src/citizen-frontend/layout/Menu.tsx
+++ b/frontend/src/citizen-frontend/layout/Menu.tsx
@@ -11,7 +11,7 @@ export default React.memo(function Menu() {
   const currentUser = user.getOrElse(undefined)
 
   return currentUser === undefined ? (
-    <a id="loginButton" className="link" href={getLoginUri()}>
+    <a data-testid="loginButton" className="link" href={getLoginUri()}>
       Kirjaudu sisään
     </a>
   ) : (

--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchFilters.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchFilters.tsx
@@ -55,6 +55,7 @@ export default React.memo(function SearchFilters({ bind }: SearchFiltersProps) {
             step={0.01}
             min={1}
             max={9999999}
+            precision={2}
           />
         </div>
         <div className="column">
@@ -69,6 +70,7 @@ export default React.memo(function SearchFilters({ bind }: SearchFiltersProps) {
             step={0.01}
             min={1}
             max={9999999}
+            precision={2}
           />
         </div>
       </div>

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/BoatInfo.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/BoatInfo.tsx
@@ -58,6 +58,7 @@ export default React.memo(function Boat({
             min={0}
             max={9999999}
             required={true}
+            precision={2}
           />
         </div>
         <div className="column is-one-quarter">
@@ -70,6 +71,7 @@ export default React.memo(function Boat({
             min={0}
             max={9999999}
             required={true}
+            precision={2}
           />
         </div>
       </div>
@@ -84,6 +86,7 @@ export default React.memo(function Boat({
             min={0}
             max={9999999}
             required={true}
+            precision={2}
           />
         </div>
         <div className="column is-one-quarter">

--- a/frontend/src/citizen-frontend/shared/formatters.ts
+++ b/frontend/src/citizen-frontend/shared/formatters.ts
@@ -14,14 +14,20 @@ export function formatDimensions({
   width: number
   length: number
 }) {
-  return `${formatNumber(width)} m x ${formatNumber(length)} m`
+  return `${formatNumber(width, 2)} m x ${formatNumber(length, 2)} m`
 }
 
-export function formatNumber(value?: number | string): string {
+export function formatNumber(
+  value?: number | string,
+  precision?: number
+): string {
+  const useDecimal = precision != undefined && precision > 0
   if (typeof value === 'string') {
-    value = parseFloat(value)
+    value = useDecimal ? parseFloat(value) : parseInt(value, 10)
   }
-  return value !== undefined ? value.toFixed(2).replace('.', ',') : ''
+  return value !== undefined
+    ? value.toFixed(precision ?? 0).replace('.', ',')
+    : ''
 }
 
 export function formatPrice(value: number): string {

--- a/frontend/src/lib-components/dom/Button.tsx
+++ b/frontend/src/lib-components/dom/Button.tsx
@@ -48,5 +48,9 @@ export default React.memo(function Button({
     props.id = id
   }
 
-  return <button {...props}>{children}</button>
+  return (
+    <button role="button" {...props}>
+      {children}
+    </button>
+  )
 })

--- a/frontend/src/lib-components/dom/Container.tsx
+++ b/frontend/src/lib-components/dom/Container.tsx
@@ -3,13 +3,19 @@ import React from 'react'
 
 export default React.memo(function Container({
   children,
-  isBlock = false
+  isBlock = false,
+  ...rest
 }: {
   children: React.ReactNode
   isBlock?: boolean
+  'data-testid'?: string
 }) {
   const classes = classNames('container', {
     block: isBlock
   })
-  return <div className={classes}>{children}</div>
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  )
 })

--- a/frontend/src/lib-components/form/NumberField.tsx
+++ b/frontend/src/lib-components/form/NumberField.tsx
@@ -15,6 +15,7 @@ interface NumberFieldProps extends Omit<BaseFieldProps, 'onChange' | 'value'> {
   min?: number
   max?: number
   value?: number | string
+  precision?: number
 }
 
 function NumberFieldR({
@@ -28,7 +29,8 @@ function NumberFieldR({
   readonly,
   value,
   showErrorsBeforeTouched,
-  required
+  required,
+  precision
 }: NumberFieldProps) {
   const { state, set, isValid, validationError, translateError } =
     bindOrPlaceholders(bind)
@@ -45,7 +47,7 @@ function NumberFieldR({
           {required && ' *'}
         </label>
         {readonly ? (
-          <ReadOnly value={formatNumber(readOnlyValue)} />
+          <ReadOnly value={formatNumber(readOnlyValue, precision)} />
         ) : (
           <>
             <input

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -106,6 +106,7 @@ export interface Translations {
     positiveNumber: string
     certify: string
     terms: string
+    validDate: string
   }
 }
 

--- a/frontend/src/lib-components/links/IconLink.tsx
+++ b/frontend/src/lib-components/links/IconLink.tsx
@@ -24,7 +24,7 @@ export default React.memo(function IconLink({
   }
 
   return (
-    <a {...props}>
+    <a role="link" {...props}>
       <span className="icon">{icon}</span>
       <span>{children}</span>
     </a>

--- a/frontend/src/lib-components/modal/Modal.tsx
+++ b/frontend/src/lib-components/modal/Modal.tsx
@@ -12,6 +12,7 @@ type ModalProperties = {
   close: () => void
   buttons?: ModalButton[]
   buttonsCentered?: boolean
+  'data-testid'?: string
 }
 
 export default React.memo(function Modal({
@@ -19,11 +20,12 @@ export default React.memo(function Modal({
   title,
   close,
   buttons,
-  buttonsCentered
+  buttonsCentered,
+  'data-testid': dataTestId
 }: ModalProperties) {
   return (
     <ModalBackground close={close}>
-      <ModalContent>
+      <ModalContent data-testid={dataTestId}>
         <ModalTitle title={title} />
         <ModalContentWrapper>{children}</ModalContentWrapper>
         <ModalButtons

--- a/frontend/src/lib-components/modal/ModalContent.tsx
+++ b/frontend/src/lib-components/modal/ModalContent.tsx
@@ -2,9 +2,15 @@ import React, { ReactNode } from 'react'
 
 type ModalContentProps = {
   children?: ReactNode | ReactNode[]
+  'data-testid'?: string
 }
 export default React.memo(function ModalContent({
-  children
+  children,
+  ...rest
 }: ModalContentProps) {
-  return <div className="modal-content mv-m">{children}</div>
+  return (
+    <div className="modal-content mv-m" {...rest}>
+      {children}
+    </div>
+  )
 })

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/en.tsx
@@ -105,7 +105,8 @@ const components: Translations = {
     selectedValuesMax: 'Select at most {max} values',
     positiveNumber: 'Enter a positive number',
     certify: 'Certify that the information you provided is correct',
-    terms: 'Accept the harbor rules'
+    terms: 'Accept the harbor rules',
+    validDate: 'Valid date format is dd.mm.yyyy'
   },
   links: {
     goBack: 'Back',

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/fi.tsx
@@ -107,7 +107,8 @@ const components: Translations = {
     selectedValuesMax: 'Valitse enintään {max} arvoa',
     positiveNumber: 'Anna positiivinen luku',
     certify: 'Vakuuta antamasi tiedot oikeiksi',
-    terms: 'Hyväksy venesatamasäännöt'
+    terms: 'Hyväksy venesatamasäännöt',
+    validDate: 'Anna muodossa pp.kk.vvvv'
   }
 }
 

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/sv.tsx
@@ -105,7 +105,8 @@ const components: Translations = {
     selectedValuesMax: 'Välj högst {max} värden',
     positiveNumber: 'Ange ett positivt tal',
     certify: 'Intyga att den information du har angett är korrekt',
-    terms: 'Godkänn hamnreglerna'
+    terms: 'Godkänn hamnreglerna',
+    validDate: 'Ange i format dd.mm.åååå'
   },
   links: {
     goBack: 'Tillbaka',

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/citizen/details/CitizenReservationsTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/citizen/details/CitizenReservationsTest.kt
@@ -2,27 +2,24 @@ package fi.espoo.vekkuli.citizen.details
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import fi.espoo.vekkuli.PlaywrightTest
-import fi.espoo.vekkuli.citizenPageInEnglish
-import fi.espoo.vekkuli.pages.CitizenDetailsPage
+import fi.espoo.vekkuli.pages.CitizenDetailsReactPage
 import fi.espoo.vekkuli.pages.CitizenHomePage
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("test")
 class CitizenReservationsTest : PlaywrightTest() {
     @Test
-    @Disabled("Waiting for React version")
     fun `citizen can see their active reservations`() {
         try {
-            val citizenDetailsPage = CitizenDetailsPage(page)
-
             CitizenHomePage(page).loginAsOliviaVirtanen()
-            page.navigate(citizenPageInEnglish)
 
-            // Opens up information from the first reservation of the first user
-            assertThat(citizenDetailsPage.locationNameInFirstBoatSpaceReservationCard).hasText("Haukilahti")
-            assertThat(citizenDetailsPage.placeInFirstBoatSpaceReservationCard).hasText("B 003")
+            val citizenDetailsPage = CitizenDetailsReactPage(page)
+            citizenDetailsPage.navigateToPage()
+
+            val firstReservationSection = citizenDetailsPage.getFirstReservationSection()
+            assertThat(firstReservationSection.locationName).hasText("Haukilahti")
+            assertThat(firstReservationSection.place).hasText("B 003")
 
             // Seed user has 2 active reservations
             assertThat(citizenDetailsPage.reservationListCards).hasCount(2)
@@ -32,17 +29,18 @@ class CitizenReservationsTest : PlaywrightTest() {
     }
 
     @Test
-    @Disabled("Waiting for React version")
     fun `citizen can see their expired reservations`() {
         try {
-            val citizenDetailsPage = CitizenDetailsPage(page)
-
             CitizenHomePage(page).loginAsOliviaVirtanen()
-            page.navigate(citizenPageInEnglish)
 
-            // Opens up information from the first reservation of the first user
-            assertThat(citizenDetailsPage.locationNameInFirstBoatSpaceReservationCard).hasText("Haukilahti")
-            assertThat(citizenDetailsPage.placeInFirstBoatSpaceReservationCard).hasText("B 003")
+            val citizenDetailsPage = CitizenDetailsReactPage(page)
+            citizenDetailsPage.navigateToPage()
+
+            citizenDetailsPage.showExpiredReservationsToggle.click()
+
+            val firstExpiredReservationSection = citizenDetailsPage.getFirstExpiredReservationSection()
+            assertThat(firstExpiredReservationSection.locationName).hasText("Haukilahti")
+            assertThat(firstExpiredReservationSection.place).hasText("B 003")
 
             // Seed user has 2 expired reservations
             assertThat(citizenDetailsPage.expiredReservationListCards).hasCount(2)

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/CitizenDetailsReactPage.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/CitizenDetailsReactPage.kt
@@ -1,0 +1,162 @@
+package fi.espoo.vekkuli.pages
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.AriaRole
+import fi.espoo.vekkuli.baseUrl
+
+class CitizenDetailsReactPage(
+    page: Page
+) : BasePage(page) {
+    inner class BoatSection(locator: Locator) {
+        val editButton = locator.getByRole(AriaRole.LINK, Locator.GetByRoleOptions().setName("Muokkaa veneen tietoja").setExact(true))
+        val saveButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Tallenna muutokset").setExact(true))
+
+        val depthField = getField("Syväys (m)", locator)
+        val depthInput = getInput("Syväys (m) *", locator)
+        val extraInformationField = getField("Lisätiedot", locator)
+        val extraInformationInput = getInput("Lisätiedot", locator)
+        val lengthField = getField("Pituus (m)", locator)
+        val lengthInput = getInput("Pituus (m) *", locator)
+        val nameField = getField("Veneen nimi", locator)
+        val nameInput = getInput("Veneen nimi *", locator)
+        val otherIdentifierField = getField("Muu tunniste", locator)
+        val otherIdentifierInput = getInput("Muu tunniste *", locator)
+        val ownershipField = getField("Omistussuhde", locator)
+        val ownershipSelect = getSelect("Omistussuhde *", locator)
+        val registrationNumberField = getField("Rekisteritunnus", locator)
+        val registrationNumberInput = getInput("Rekisteritunnus", locator)
+        val typeField = getField("Veneen tyyppi", locator)
+        val typeSelect = getSelect("Veneen tyyppi *", locator)
+        val weightField = getField("Paino (kg)", locator)
+        val weightInput = getInput("Paino (kg) *", locator)
+        val widthField = getField("Leveys (m)", locator)
+        val widthInput = getInput("Leveys (m) *", locator)
+    }
+
+    inner class CitizenSection(locator: Locator) {
+        val editButton = locator.getByRole(AriaRole.LINK, Locator.GetByRoleOptions().setName("Muokkaa").setExact(true))
+        val saveButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Tallenna muutokset").setExact(true))
+
+        val emailError = getInputError("Sähköposti", locator)
+        val emailField = getField("Sähköposti", locator)
+        val emailInput = getInput("Sähköposti", locator)
+        val municipalityField = getField("Kotikunta", locator)
+        val phoneError = getInputError("Puhelinnumero", locator)
+        val phoneField = getField("Puhelinnumero", locator)
+        val phoneInput = getInput("Puhelinnumero", locator)
+    }
+
+    inner class ReservationSection(locator: Locator) {
+        val terminateButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Irtisano paikka").setExact(true))
+
+        val locationName = getField("Satama", locator)
+        val place = getField("Paikka", locator)
+
+        val trailerSection = TrailerSection(getByDataTestId("trailer-information", locator))
+    }
+
+    inner class TrailerSection(locator: Locator) {
+        val editButton = locator.getByRole(AriaRole.LINK, Locator.GetByRoleOptions().setName("Muokkaa trailerin tietoja").setExact(true))
+        val saveButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Tallenna muutokset").setExact(true))
+        val cancelButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Peruuta").setExact(true))
+
+        val lengthField = getField("Pituus (m)", locator)
+        val lengthInput = getInput("Pituus (m)", locator)
+
+        val registrationCodeField = getField("Rekisterinumero", locator)
+        val registrationCodeInput = getInput("Rekisterinumero", locator)
+
+        val widthField = getField("Leveys (m)", locator)
+        val widthInput = getInput("Leveys (m)", locator)
+    }
+
+    inner class TerminateReservationModal(locator: Locator) {
+        val element = locator
+        val cancelButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Peruuta").setExact(true))
+        val confirmButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Irtisano venepaikka").setExact(true))
+
+        val placeIdentifierText = getByDataTestId("place-identifier", locator)
+        val boatSpaceText = getByDataTestId("boat-space", locator)
+        val amenityText = getByDataTestId("amenity", locator)
+    }
+
+    inner class TerminateReservationFailureModal(locator: Locator) {
+        val element = locator
+        val okButton = locator.getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName("Ok").setExact(true))
+    }
+
+    fun navigateToPage() {
+        page.navigate("$baseUrl/kuntalainen/omat-tiedot?lang=en")
+    }
+
+//    fun hideModalWindow() {
+//        modalWindow.click(
+//            Locator
+//                .ClickOptions()
+//                .setPosition(5.0, 5.0)
+//        )
+//    }
+
+    fun getCitizenSection() = CitizenSection(getByDataTestId("citizen-information"))
+
+    fun getBoatSection(id: Int) = BoatSection(getByDataTestId("boat-$id"))
+
+    val showAllBoatsButton = getInput("Näytä myös veneet joita ei ole liitetty venepaikkoihin")
+
+    val reservationList = getByDataTestId("reservation-list")
+    val reservationListCards = getByDataTestId("reservation-list-card", reservationList)
+
+    fun getReservationSection(nth: Int) = ReservationSection(reservationListCards.nth(nth))
+
+    fun getFirstReservationSection() = getReservationSection(0)
+
+    val expiredReservationList = getByDataTestId("expired-reservation-list")
+    val expiredReservationListCards = getByDataTestId("reservation-list-card", expiredReservationList)
+
+    fun getExpiredReservationSection(nth: Int) = ReservationSection(expiredReservationListCards.nth(nth))
+
+    fun getFirstExpiredReservationSection() = getExpiredReservationSection(0)
+
+    val showExpiredReservationsToggle = expiredReservationList.getByText("Päättyneet varaukset")
+
+    fun getTerminateReservationModal() = TerminateReservationModal(getByDataTestId("terminate-reservation-modal"))
+
+    fun getTerminateReservationFailureModal() = TerminateReservationFailureModal(getByDataTestId("terminate-reservation-failure-modal"))
+
+    val terminateReservationSuccessModal = getByDataTestId("terminate-reservation-success-modal")
+
+    private fun getInput(
+        label: String,
+        locator: Locator? = null
+    ) = getInputWrapper(label, locator).locator("input")
+
+    private fun getSelect(
+        label: String,
+        locator: Locator? = null
+    ) = getInputWrapper(label, locator).locator("select")
+
+    private fun getField(
+        label: String,
+        locator: Locator? = null
+    ) = getInputWrapper(label, locator).locator("p")
+
+    private fun getInputError(
+        label: String,
+        locator: Locator? = null
+    ) = getInputWrapper(label, locator).locator(".help.is-danger")
+
+    private fun getInputWrapper(
+        label: String,
+        locator: Locator? = null
+    ): Locator {
+        val labelElement =
+            if (locator != null) {
+                locator.locator("label", Locator.LocatorOptions().setHasText(label))
+            } else {
+                page.locator("label", Page.LocatorOptions().setHasText(label))
+            }
+
+        return labelElement.locator("..")
+    }
+}

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/CitizenHomePage.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/CitizenHomePage.kt
@@ -20,8 +20,8 @@ class CitizenHomePage(
 
     fun loginAsCitizen(ssn: String) {
         page.navigate(baseUrl)
-        page.getByTestId("loginButton").click()
-        page.getByTestId(ssn).click()
+        getByDataTestId("loginButton").click()
+        getByDataTestId(ssn).click()
         page.getByText("Kirjaudu").click()
     }
 }


### PR DESCRIPTION
Fixes few citizen details related E2E tests and few issues in the page that were found by the fixed tests.

Tests currently use Finnish because localization is not yet complete. The language can be changed later. Alternatively, if ids or data-testids are preferred, they could be used instead. However, using human-readable text should be preferred, as it ensures tests reference content visible to the user. Some tests are incomplete because of missing features.

Issues fixed:
- expired reservations list was not updated after terminating active one
- removed decimals from boat weight
- added decimals to boat length
- citizen email form validation added
- citizen phone number form validation added
- missing translation for validDate