### PR TITLE
Keyboard access to links

### DIFF
--- a/frontend/src/citizen-frontend/reservation/components/ReservationCancel.tsx
+++ b/frontend/src/citizen-frontend/reservation/components/ReservationCancel.tsx
@@ -12,11 +12,13 @@ import { cancelReservationMutation } from '../queries'
 export default React.memo(function ReservationCancel({
   reservationId,
   type,
-  children
+  children,
+  buttonAriaLabel
 }: {
   reservationId: number
   type: 'link' | 'button'
   children: React.ReactNode
+  buttonAriaLabel?: string
 }) {
   const i18n = useTranslation()
   const [modalOpen, setModalOpen] = React.useState(false)
@@ -53,9 +55,13 @@ export default React.memo(function ReservationCancel({
 
   const button =
     type === 'link' ? (
-      <GoBackLink action={() => setModalOpen(true)}>{children}</GoBackLink>
+      <GoBackLink action={() => setModalOpen(true)} ariaLabel={buttonAriaLabel}>
+        {children}
+      </GoBackLink>
     ) : (
-      <Button action={() => setModalOpen(true)}>{children}</Button>
+      <Button ariaLabel={buttonAriaLabel} action={() => setModalOpen(true)}>
+        {children}
+      </Button>
     )
 
   return (

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/FormPage.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/FormPage.tsx
@@ -41,6 +41,7 @@ export default React.memo(function FormPage() {
                 <ReservationCancel
                   reservationId={loadedReservation.id}
                   type="link"
+                  buttonAriaLabel={i18n.reservation.cancelAndGoBack}
                 >
                   {i18n.components.links.goBack}
                 </ReservationCancel>

--- a/frontend/src/lib-components/dom/Button.tsx
+++ b/frontend/src/lib-components/dom/Button.tsx
@@ -9,6 +9,7 @@ export type ButtonProps = {
   type?: ButtonType
   action?: () => void
   loading?: boolean
+  ariaLabel?: string
 }
 
 export default React.memo(function Button({
@@ -16,7 +17,8 @@ export default React.memo(function Button({
   action,
   id,
   type,
-  loading
+  loading,
+  ariaLabel
 }: ButtonProps) {
   const classes = ['button']
   switch (type) {
@@ -49,7 +51,7 @@ export default React.memo(function Button({
   }
 
   return (
-    <button role="button" {...props}>
+    <button role="button" aria-label={ariaLabel} {...props}>
       {children}
     </button>
   )

--- a/frontend/src/lib-components/links/GoBackLink.tsx
+++ b/frontend/src/lib-components/links/GoBackLink.tsx
@@ -10,19 +10,26 @@ export type GoBackLinkProps = {
   children?: React.ReactNode
   action?: () => void
   href?: string
+  ariaLabel?: string
 }
 
 export default React.memo(function GoBackLink({
   children,
   action,
-  href
+  href,
+  ariaLabel
 }: GoBackLinkProps) {
   const navigate = useNavigate()
   const i18n = useTranslation()
   const defaultedAction = !action && !href ? () => navigate(-1) : action
   const defaultedChildren = children || i18n.components.links.goBack
   return (
-    <IconLink icon={<ChevronLeft />} action={defaultedAction} href={href}>
+    <IconLink
+      icon={<ChevronLeft />}
+      action={defaultedAction}
+      href={href}
+      ariaLabel={ariaLabel}
+    >
       {defaultedChildren}
     </IconLink>
   )

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
@@ -217,6 +217,7 @@ const en: Translations = {
       'You are about to leave the reservation form. Please note that the space reservation or entered information will not be saved.',
     cancelConfirmation2: 'Do you want to continue?',
     cancelReservation: 'Cancel reservation',
+    cancelAndGoBack: 'Cancel and go back',
     continueToPaymentButton: 'Continue to payment'
   },
   boatSpace: {

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
@@ -214,6 +214,7 @@ export default {
       'Olet poistumassa varauslomakkeelta. Huomioi, että paikkavarausta tai syötettyjä tietoja ei tallenneta.',
     cancelConfirmation2: 'Haluatko jatkaa?',
     cancelReservation: 'Peruuta varaus',
+    cancelAndGoBack: 'Peruuta varaus ja palaa takaisin',
     continueToPaymentButton: 'Jatka maksamaan'
   },
   boatSpace: {

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
@@ -216,6 +216,7 @@ const sv: Translations = {
       'Du är på väg att lämna bokningsformuläret. Observera att platsbokningen eller inmatad information inte kommer att sparas.',
     cancelConfirmation2: 'Vill du fortsätta?',
     cancelReservation: 'Avbryt reservation',
+    cancelAndGoBack: 'Avbryt och gå tillbaka',
     continueToPaymentButton: 'Fortsätt till betalning'
   },
   boatSpace: {


### PR DESCRIPTION
Linkkien saavutettavuus näppäimistönavigoinnilla (Tuli käytännössä sisään jo PR #628 ) - tähän jäi aria-labelin lisäys/selitys "Takaisin"-linkkiin.