### PR TITLE
Remove aria-describedby from CheckboxField

### DIFF
--- a/frontend/src/lib-components/form/CheckboxField.tsx
+++ b/frontend/src/lib-components/form/CheckboxField.tsx
@@ -48,7 +48,6 @@ function CheckboxFieldR<T>({
     }
   }
   const readOnlyValue = state !== undefined ? state.domValues[0] : value
-  const errorFieldId = id && `error-${id}`
   return (
     <div>
       {!label ? null : (
@@ -72,7 +71,6 @@ function CheckboxFieldR<T>({
                 label={option.label}
                 isFullWidth={isFullWidth}
                 ariaInvalid={showError}
-                ariaDescribedBy={errorFieldId}
               />
             ))}
             {showError && (
@@ -81,7 +79,6 @@ function CheckboxFieldR<T>({
                   showError={showError}
                   error={validationError()}
                   translateError={translateError}
-                  id={errorFieldId}
                 />
               </div>
             )}
@@ -111,8 +108,7 @@ const CheckboxFieldInput = React.memo(function CheckboxFieldInput({
   selected,
   onChange,
   isFullWidth,
-  ariaInvalid,
-  ariaDescribedBy
+  ariaInvalid
 }: CheckboxFieldInputProps) {
   return (
     <Column isFull={isFullWidth} isHalf={!isFullWidth} noBottomPadding>
@@ -124,7 +120,6 @@ const CheckboxFieldInput = React.memo(function CheckboxFieldInput({
           checked={selected}
           type="checkbox"
           aria-invalid={ariaInvalid}
-          aria-describedby={ariaDescribedBy}
           onChange={(e) => {
             e.stopPropagation()
             onChange?.(e.target.checked)


### PR DESCRIPTION
Revertti checkboxFieldin screen-readerin virheen lausumiseen - checkboxissa FieldErrorContainer ei ole koko ajan domissa ja komponenttia käytetään _enimmäkseen_ kohdissa joissa ne eivät ole _required_ -> tuottivat saavutettavuusvalidaattoreille enemmän haittaa kuin hyötyä