### PR TITLE
Increase form element focus contrast for keyboard navigation

### DIFF
--- a/frontend/src/citizen-frontend/main.scss
+++ b/frontend/src/citizen-frontend/main.scss
@@ -85,6 +85,10 @@ input:focus-visible, input.input:focus-visible,
   outline: 2px solid $bulma-primary;
   outline-offset: 2px;
   box-shadow: none;
+  &.is-danger {
+    outline-color: $bulma-danger;
+    border-color: $bulma-danger;
+  }
 }
 
 html, body {


### PR DESCRIPTION
`:focus-visible` -tilaa päivitetty näppäimistönavigaation selkeyttämiseksi. 
https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html 

| Ennen | Jälkeen |
| -------- | -------- |
| <img width="339" alt="Screenshot 2025-01-22 at 12 52 33" src="https://github.com/user-attachments/assets/9b9b569e-0b2d-4426-8e84-c97fedc9d0a8" /> | <img width="340" alt="Screenshot 2025-01-22 at 12 55 43" src="https://github.com/user-attachments/assets/ada4a2aa-1726-42f7-97d2-6f42ab66a1b0" /> |
| <img width="456" alt="Screenshot 2025-01-22 at 12 52 53" src="https://github.com/user-attachments/assets/81a96b2a-28ef-4aa3-973e-e4e298e6ef3e" /> | <img width="456" alt="Screenshot 2025-01-22 at 12 56 09" src="https://github.com/user-attachments/assets/48e36c2c-d31b-4264-8367-9795b328de24" /> |
| <img width="581" alt="Screenshot 2025-01-22 at 12 53 36" src="https://github.com/user-attachments/assets/1e7d23db-6d13-42ce-975f-97153204a813" /> | <img width="543" alt="Screenshot 2025-01-22 at 12 56 45" src="https://github.com/user-attachments/assets/b8dee434-bb82-42c3-bf87-e41e1efc4d7f" /> |
| <img width="546" alt="Screenshot 2025-01-22 at 12 54 18" src="https://github.com/user-attachments/assets/0e6b1a2f-4abe-4944-982b-4bb76d4fc37b" /> | <img width="563" alt="Screenshot 2025-01-22 at 12 57 12" src="https://github.com/user-attachments/assets/b85ac841-a14a-49d0-925a-5995dc5c2384" /> |





