### PR TITLE
Fix heading hierarchy

### DIFF
--- a/frontend/src/citizen-frontend/main.scss
+++ b/frontend/src/citizen-frontend/main.scss
@@ -124,7 +124,7 @@ html, body {
   opacity: 1;
 }
 
-h1 {
+h1, h2.h1 {
   font-size: 32px;
   font-weight: 700;
   line-height: 40px;

--- a/frontend/src/citizen-frontend/reservation/pages/confirmation/ConfirmationPage.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/confirmation/ConfirmationPage.tsx
@@ -38,7 +38,7 @@ const Content = React.memo(function Content({
     <Loader results={[reservation]}>
       {(loadedReservation) => (
         <>
-          <h1>Venepaikan varaus onnistui</h1>
+          <h2 className="h1">Venepaikan varaus onnistui</h2>
           <div className="container">
             <ul className="has-bullets ml-none">
               <li>

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/Form.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/Form.tsx
@@ -127,7 +127,7 @@ export default React.memo(function Form({
   return (
     <>
       <form id="form" className="column" onSubmit={(e) => e.preventDefault()}>
-        <h1 className="title pb-l" id="boat-space-form-header">
+        <h2 className="title pb-l" id="boat-space-form-header">
           {i18n.reservation.formPage.title[updatedReservation.boatSpace.type](
             formatPlaceIdentifier(
               updatedReservation.boatSpace.section,
@@ -135,7 +135,7 @@ export default React.memo(function Form({
               updatedReservation.boatSpace.locationName
             )
           )}
-        </h1>
+        </h2>
         <Block>
           {reservation.creationType === 'Switch' && (
             <InfoBox text={i18n.reservation.formPage.info.switch} />


### PR DESCRIPTION
Vaihdettu sivuilla "Venepaikan varaus onnistui" ja "Venepaikan varaus / tietojen täyttäminen" `<h1>`-otsikot `<h2>`-tasolle. Toisen projektin auditissa otsikkohierarkia oli kategoriassa "kriittiset havainnot".
Otsikoiden tyylit muokattu siten että näyttävät samalta muutoksen jälkeen.