### PR TITLE
Differentiate duplicate form labels for screen reader

### DIFF
--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/organization/WithOrganization.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/organization/WithOrganization.tsx
@@ -2,6 +2,7 @@ import { Column, Columns } from 'lib-components/dom'
 import { FormSection, SelectField, TextField } from 'lib-components/form'
 import React from 'react'
 
+import { useTranslation } from 'citizen-frontend/localization'
 import { BoundForm, useFormFields } from 'lib-common/form/hooks'
 
 import { OrganizationInfoForm } from '../../formDefinitions/organization'
@@ -21,6 +22,8 @@ export const WithOrganization = React.memo(function Organization({
     streetAddress,
     municipality
   } = useFormFields(bind)
+
+  const i18n = useTranslation()
 
   return (
     <FormSection>
@@ -57,6 +60,7 @@ export const WithOrganization = React.memo(function Organization({
             label="Puhelinnumero"
             required={true}
             bind={phone}
+            ariaLabel={i18n.organization.organizationPhone}
           />
         </Column>
         <Column isOneQuarter>
@@ -65,6 +69,7 @@ export const WithOrganization = React.memo(function Organization({
             label="Sähköposti"
             required={true}
             bind={email}
+            ariaLabel={i18n.organization.organizationEmail}
           />
         </Column>
         <Column isOneQuarter>

--- a/frontend/src/lib-components/form/BaseField.tsx
+++ b/frontend/src/lib-components/form/BaseField.tsx
@@ -18,4 +18,5 @@ export interface BaseFieldProps<TValue = string> {
   ariaRequired?: boolean
   ariaInvalid?: boolean
   ariaDescribedBy?: string
+  ariaLabel?: string
 }

--- a/frontend/src/lib-components/form/TextField.tsx
+++ b/frontend/src/lib-components/form/TextField.tsx
@@ -21,7 +21,8 @@ export default React.memo(function TextField({
   readonly,
   required,
   value,
-  showErrorsBeforeTouched
+  showErrorsBeforeTouched,
+  ariaLabel
 }: TextFieldProps) {
   const { showAllErrors } = useFormErrorContext()
   const { state, set, isValid, validationError, translateError } =
@@ -50,6 +51,7 @@ export default React.memo(function TextField({
               id={id}
               name={name}
               value={state}
+              aria-label={ariaLabel}
               aria-required={required}
               aria-invalid={showError}
               aria-describedby={errorFieldId}

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
@@ -381,6 +381,10 @@ const en: Translations = {
       }
     }
   },
+  organization: {
+    organizationPhone: 'Organization phone number',
+    organizationEmail: 'Organization email'
+  },
   payment: {
     title: 'Choose payment method'
   }

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
@@ -381,6 +381,10 @@ export default {
       }
     }
   },
+  organization: {
+    organizationPhone: 'Yhteisön puhelinnumero',
+    organizationEmail: 'Yhteisön sähköposti'
+  },
   payment: {
     title: 'Valitse maksutapa'
   }

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
@@ -382,6 +382,10 @@ const sv: Translations = {
       }
     }
   },
+  organization: {
+    organizationPhone: 'Organisationens telefonnummer',
+    organizationEmail: 'Organisationens e-post'
+  },
   payment: {
     title: 'Välj betalningsmetod'
   }


### PR DESCRIPTION
Tarkennus ruudunlukijalle samannimisistä formin kentistä -> "Tietojen täyttäminen" -> "Vuokralainen" -> "Varaan yhteisön puolesta", aria-labeliin tieto "Yhteisön puhelinnumero" / "Yhteisön sähköposti".

<img width="518" alt="Screenshot 2025-01-28 at 13 28 58" src="https://github.com/user-attachments/assets/70b88c61-5253-4aa2-9dd8-57ce31464e0c" />
