### PR TITLE
Assign aria-properties to step indicator

### DIFF
--- a/frontend/src/citizen-frontend/reservation/StepIndicator.tsx
+++ b/frontend/src/citizen-frontend/reservation/StepIndicator.tsx
@@ -20,13 +20,19 @@ export default React.memo(function StepIndicator({ step }: StepIndicatorProps) {
   const currentStepSequence = steps.indexOf(step)
   return (
     <div className="container" id="step-indicator">
-      <div className="columns is-mobile" id="step-indicator-step">
+      <div
+        className="columns is-mobile"
+        id="step-indicator-step"
+        role="list"
+        aria-label={i18n.components.stepIndicator.title}
+      >
         {steps.map((s, index) => (
           <Step
             key={s}
             step={s}
             visited={index <= currentStepSequence}
             i18n={i18n}
+            currentStep={index === currentStepSequence}
           />
         ))}
       </div>
@@ -38,14 +44,24 @@ type StepProps = {
   step: Step
   visited: boolean
   i18n: Translations
+  currentStep: boolean
 }
 
-const Step = React.memo(function Step({ step, visited, i18n }: StepProps) {
+const Step = React.memo(function Step({
+  step,
+  visited,
+  i18n,
+  currentStep
+}: StepProps) {
   return (
-    <div className="column">
+    <div
+      className="column"
+      aria-current={currentStep ? 'page' : undefined}
+      role="listitem"
+    >
       <div
-        id="chooseBoatSpace"
         className={classNames('step mb-m', { visited: visited })}
+        aria-hidden={true}
       />
       <p className="is-uppercase has-text-centered title is-7">
         {i18n.reservation.steps[step]}

--- a/frontend/src/lib-components/i18n.tsx
+++ b/frontend/src/lib-components/i18n.tsx
@@ -83,6 +83,9 @@ export interface Translations {
     collapse: (opt: string) => string
     expandDropdown: string
   }
+  stepIndicator: {
+    title: string
+  }
   validationErrors: {
     required: string
     requiredSelection: string

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/en.tsx
@@ -82,6 +82,9 @@ const components: Translations = {
     collapse: () => '',
     expandDropdown: ''
   },
+  stepIndicator: {
+    title: 'Reservation steps'
+  },
   validationErrors: {
     required: 'Value missing',
     requiredSelection: 'Please select one of the options',

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/fi.tsx
@@ -85,6 +85,9 @@ const components: Translations = {
     collapse: (opt: string) => `Sulje vaihtoehdon ${opt} alaiset vaihtoehdot`,
     expandDropdown: 'Avaa'
   },
+  stepIndicator: {
+    title: 'Varauksen vaiheet'
+  },
   validationErrors: {
     required: 'Tämä kenttä on pakollinen',
     requiredSelection: 'Valinta puuttuu',

--- a/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/components/i18n/sv.tsx
@@ -82,6 +82,9 @@ const components: Translations = {
     collapse: () => '',
     expandDropdown: ''
   },
+  stepIndicator: {
+    title: 'Bokningssteg'
+  },
   validationErrors: {
     required: 'Värde saknas',
     requiredSelection: 'Val saknas',


### PR DESCRIPTION
<img width="1404" alt="Screenshot 2025-01-29 at 14 13 49" src="https://github.com/user-attachments/assets/8be00f99-466a-4f81-8237-dabcfadbcc78" />

_Ennen muutosta:_

Ruudunlukijan näkökulmasta StepIndicator-komponentti ei kerro kontekstia. Vain labelit lausutaan erillisinä.

_Muutoksen jälkeen:_

Lisätty aria-label "Varauksen vaiheet" (käännökset muun sisällön mukaan + AI). Lisätty currentPage -prop "nykyiselle" sivulle/vaiheelle, jonka avulla aria-currentia käyttäen ruudunlukija osaa kertoa valitun sivun. Asetettu role="list" steppien wrapperille jolloin ruudunlukija lausuu otsikon lisäksi (kielestä riippuen) "1 of 4" jne. jolloin ruudunlukijan käyttäjä saa käsityksen vaiheiden määrästä.