### PR TITLE
Enforce focus to error box for screen reader

### DIFF
--- a/frontend/src/citizen-frontend/reservation/components/ErrorBox.tsx
+++ b/frontend/src/citizen-frontend/reservation/components/ErrorBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import { WarningExclamation } from 'lib-icons/vekkuli-icons'
 
@@ -7,14 +7,30 @@ export const ErrorBox = React.memo(function ErrorBox({
 }: {
   text: string
 }) {
+  // Set focus with delay explicitly to the error box when it is rendered to
+  // make sure that screen reader users are notified about the error.
+  const errorBoxRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+        errorBoxRef.current?.focus()
+      })
+    }, 250)
+  }, [])
   return (
-    <div className="message-box is-error column is-four-fifths">
-      <div className="column is-narrow">
+    <div
+      className="message-box is-error column is-four-fifths"
+      ref={errorBoxRef}
+      tabIndex={-1}
+    >
+      <div className="column is-narrow" aria-hidden="true">
         <span className="icon">
           <WarningExclamation isError={false} />
         </span>
       </div>
-      <p className="column">{text}</p>
+      <p role="alert" className="column">
+        {text}
+      </p>
     </div>
   )
 })


### PR DESCRIPTION
Lisäys maksun epäonnistumisesta kertovaan komponenttiin - asetetaan focus viiveellä jotta mahdolliset muut ruudunlukijan kohdistuksesta kilpailevat elementit ovat ns. alta pois. Timeoutin arvo 250ms (+requestAnimationFrame) tulivat testaillessa safari/chrome/firefox -yhdistelmillä.