### PR TITLE
Fix updating organization trailer not invalidating relevant queries

### DIFF
--- a/frontend/src/citizen-frontend/citizen/CitizenPage.tsx
+++ b/frontend/src/citizen-frontend/citizen/CitizenPage.tsx
@@ -10,13 +10,15 @@ import { useQueryResult } from 'lib-common/query'
 
 import ExpiredReservations from '../components/reservation-list/ExpiredReservations'
 import Reservations from '../components/reservation-list/Reservations'
+
 import {
   citizenActiveReservationsQuery,
   citizenExpiredReservationsQuery,
   citizenOrganizationQuery,
   deleteCitizenBoatMutation,
   terminateCitizenReservationMutation,
-  updateCitizenBoatMutation
+  updateCitizenBoatMutation,
+  updateCitizenTrailerMutation
 } from './queries'
 import CitizenInformation from './sections/citizenInformation'
 
@@ -62,6 +64,7 @@ const Content = React.memo(function Content({
               <Reservations
                 reservations={loadedActiveReservations}
                 terminateMutation={terminateCitizenReservationMutation}
+                updateTrailerMutation={updateCitizenTrailerMutation}
               />
               <Boats
                 boats={loadedBoats}

--- a/frontend/src/citizen-frontend/components/boat-list/Boat.tsx
+++ b/frontend/src/citizen-frontend/components/boat-list/Boat.tsx
@@ -12,18 +12,20 @@ import { useForm, useFormFields } from 'lib-common/form/hooks'
 import { MutationDescription, useMutation } from 'lib-common/query'
 
 import { boatForm, transformBoatToFormBoat } from './formDefinitions'
+import { updateBoatDisabled } from './queries'
 
 type BoatProps = {
   boat: Boat
   onDelete?: () => void
-  updateMutation: MutationDescription<UpdateBoatRequest, void>
+  updateMutation?: MutationDescription<UpdateBoatRequest, void>
 }
 
 export default React.memo(function Boat({
   boat,
   onDelete,
-  updateMutation
+  updateMutation = updateBoatDisabled
 }: BoatProps) {
+  const editDisabled = updateMutation === updateBoatDisabled
   const i18n = useTranslation()
   const bind = useForm(
     boatForm,
@@ -70,9 +72,11 @@ export default React.memo(function Boat({
               </Column>
             )}
             <Column isNarrow toRight>
-              <EditLink action={() => setEditMode(true)}>
-                Muokkaa veneen tietoja
-              </EditLink>
+              {!editDisabled && (
+                <EditLink action={() => setEditMode(true)}>
+                  Muokkaa veneen tietoja
+                </EditLink>
+              )}
             </Column>
           </Columns>
         </Column>

--- a/frontend/src/citizen-frontend/components/boat-list/Boats.tsx
+++ b/frontend/src/citizen-frontend/components/boat-list/Boats.tsx
@@ -8,20 +8,19 @@ import { MutationDescription } from 'lib-common/query'
 
 import BoatComponent from './Boat'
 import BoatsNotInReservation from './BoatsNotInReservation'
-import { deleteBoatMutation, updateBoatMutation } from './queries'
 
 type BoatsProps = {
   boats: Boat[]
   activeReservations: ExistingBoatSpaceReservation[]
-  deleteMutation: MutationDescription<BoatId, void>
-  updateMutation: MutationDescription<UpdateBoatRequest, void>
+  deleteMutation?: MutationDescription<BoatId, void>
+  updateMutation?: MutationDescription<UpdateBoatRequest, void>
 }
 
 export default React.memo(function Boats({
   boats,
   activeReservations,
-  deleteMutation = deleteBoatMutation,
-  updateMutation = updateBoatMutation
+  deleteMutation,
+  updateMutation
 }: BoatsProps) {
   return (
     <Container isBlock data-testid="boat-list">

--- a/frontend/src/citizen-frontend/components/boat-list/BoatsNotInReservation.tsx
+++ b/frontend/src/citizen-frontend/components/boat-list/BoatsNotInReservation.tsx
@@ -12,18 +12,20 @@ import ConfirmDeleteBoatModal from './ConfirmDeleteBoatModal'
 import DeleteBoatFailedModal from './DeleteBoatFailedModal'
 import DeleteBoatSuccessModal from './DeleteBoatSuccessModal'
 import { initShowBoatsForm, showBoatsForm } from './formDefinitions'
+import { deleteBoatDisabled } from './queries'
 
 type BoatsNotInreservationsProps = {
   boats: Boat[]
-  deleteMutation: MutationDescription<BoatId, void>
-  updateMutation: MutationDescription<UpdateBoatRequest, void>
+  deleteMutation?: MutationDescription<BoatId, void>
+  updateMutation?: MutationDescription<UpdateBoatRequest, void>
 }
 
 export default React.memo(function BoatsNotInreservations({
   boats,
-  deleteMutation,
-  updateMutation
+  updateMutation,
+  deleteMutation = deleteBoatDisabled
 }: BoatsNotInreservationsProps) {
+  const deleteDisabled = deleteMutation === deleteBoatDisabled
   const i18n = useTranslation()
 
   const [boatPendingDeletion, setBoatPendingDeletion] = useState<Boat | null>(
@@ -55,7 +57,11 @@ export default React.memo(function BoatsNotInreservations({
                 <BoatComponent
                   key={boat.id}
                   boat={boat}
-                  onDelete={() => setBoatPendingDeletion(boat)}
+                  onDelete={
+                    deleteDisabled
+                      ? undefined
+                      : () => setBoatPendingDeletion(boat)
+                  }
                   updateMutation={updateMutation}
                 />
               ))}

--- a/frontend/src/citizen-frontend/components/boat-list/queries.ts
+++ b/frontend/src/citizen-frontend/components/boat-list/queries.ts
@@ -1,12 +1,11 @@
-import { deleteBoat, updateBoat } from 'citizen-frontend/api-clients/boat'
-import { queryKeys } from 'citizen-frontend/shared/queries'
-import { mutation } from 'lib-common/query'
+import { UpdateBoatRequest } from 'citizen-frontend/api-clients/boat'
+import { BoatId } from 'citizen-frontend/shared/types'
 
-export const deleteBoatMutation = mutation({
-  api: deleteBoat,
-  invalidateQueryKeys: () => [queryKeys.citizenBoats()]
-})
+import { createMutationDisabledDefault } from '../util'
 
-export const updateBoatMutation = mutation({
-  api: updateBoat
-})
+export const deleteBoatDisabled = createMutationDisabledDefault<BoatId, void>()
+
+export const updateBoatDisabled = createMutationDisabledDefault<
+  UpdateBoatRequest,
+  void
+>()

--- a/frontend/src/citizen-frontend/components/reservation-list/Reservation.tsx
+++ b/frontend/src/citizen-frontend/components/reservation-list/Reservation.tsx
@@ -4,12 +4,16 @@ import TextField from 'lib-components/form/TextField'
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { UpdateTrailerRequest } from 'citizen-frontend/api-clients/trailer'
 import { ExistingBoatSpaceReservation } from 'citizen-frontend/api-types/reservation'
-import { updateCitizenTrailerMutation } from 'citizen-frontend/citizen/queries'
 import TrailerInformation from 'citizen-frontend/components/trailer/TrailerInformation'
 import { useTranslation } from 'citizen-frontend/localization'
 import { formatPlaceIdentifier } from 'citizen-frontend/shared/formatters'
-import { useMutation, useQueryResult } from 'lib-common/query'
+import {
+  MutationDescription,
+  useMutation,
+  useQueryResult
+} from 'lib-common/query'
 
 import ErrorModal, {
   ErrorCode
@@ -20,10 +24,12 @@ import { startRenewReservationMutation } from './queries'
 
 export default React.memo(function Reservation({
   reservation,
-  onTerminate
+  onTerminate,
+  updateTrailerMutation
 }: {
   reservation: ExistingBoatSpaceReservation
   onTerminate?: () => void
+  updateTrailerMutation?: MutationDescription<UpdateTrailerRequest, void>
 }) {
   const canSwitch = reservation.allowedReservationOperations.includes('Switch')
   const canRenew = reservation.allowedReservationOperations.includes('Renew')
@@ -161,7 +167,7 @@ export default React.memo(function Reservation({
           <TrailerInformation
             trailer={reservation.trailer}
             setEditIsOn={(mode) => setButtonsVisible(!mode)}
-            updateMutation={updateCitizenTrailerMutation}
+            updateMutation={updateTrailerMutation}
           />
         )}
         {buttonsVisible && (

--- a/frontend/src/citizen-frontend/components/reservation-list/Reservations.tsx
+++ b/frontend/src/citizen-frontend/components/reservation-list/Reservations.tsx
@@ -1,6 +1,7 @@
 import { Container } from 'lib-components/dom'
 import React, { useState } from 'react'
 
+import { UpdateTrailerRequest } from 'citizen-frontend/api-clients/trailer'
 import { ExistingBoatSpaceReservation } from 'citizen-frontend/api-types/reservation'
 import { ReservationId } from 'citizen-frontend/shared/types'
 import { MutationDescription } from 'lib-common/query'
@@ -9,15 +10,18 @@ import Reservation from './Reservation'
 import TerminateModal from './TerminateModal'
 import TerminateModalFailure from './TerminateModalFailure'
 import TerminateModalSuccess from './TerminateModalSuccess'
-import { terminateReservationMutation } from './queries'
+import { terminateReservationDisabled } from './queries'
 
 export default React.memo(function Reservations({
   reservations,
-  terminateMutation = terminateReservationMutation
+  updateTrailerMutation,
+  terminateMutation = terminateReservationDisabled
 }: {
   reservations: ExistingBoatSpaceReservation[]
-  terminateMutation: MutationDescription<ReservationId, void>
+  terminateMutation?: MutationDescription<ReservationId, void>
+  updateTrailerMutation: MutationDescription<UpdateTrailerRequest, void>
 }) {
+  const terminationDisabled = terminateMutation === terminateReservationDisabled
   const [reservationPendingTermination, setReservationPendingTermination] =
     useState<ExistingBoatSpaceReservation | null>(null)
   const [reservationTerminateSuccess, setReservationTerminateSuccess] =
@@ -35,9 +39,12 @@ export default React.memo(function Reservations({
               <Reservation
                 key={reservation.id}
                 reservation={reservation}
-                onTerminate={() =>
-                  setReservationPendingTermination(reservation)
+                onTerminate={
+                  terminationDisabled
+                    ? undefined
+                    : () => setReservationPendingTermination(reservation)
                 }
+                updateTrailerMutation={updateTrailerMutation}
               />
             ))}
           </div>

--- a/frontend/src/citizen-frontend/components/reservation-list/queries.ts
+++ b/frontend/src/citizen-frontend/components/reservation-list/queries.ts
@@ -1,14 +1,14 @@
-import {
-  startRenewReservation,
-  terminateReservation
-} from 'citizen-frontend/api-clients/reservation'
+import { startRenewReservation } from 'citizen-frontend/api-clients/reservation'
+import { ReservationId } from 'citizen-frontend/shared/types'
 import { mutation } from 'lib-common/query'
 
 import { queryKeys } from '../../citizen/queries'
+import { createMutationDisabledDefault } from '../util'
 
-export const terminateReservationMutation = mutation({
-  api: terminateReservation
-})
+export const terminateReservationDisabled = createMutationDisabledDefault<
+  ReservationId,
+  void
+>()
 
 export const startRenewReservationMutation = mutation({
   api: startRenewReservation,

--- a/frontend/src/citizen-frontend/components/trailer/TrailerInformation.tsx
+++ b/frontend/src/citizen-frontend/components/trailer/TrailerInformation.tsx
@@ -10,17 +10,18 @@ import { useForm, useFormFields } from 'lib-common/form/hooks'
 import { MutationDescription, useMutation } from 'lib-common/query'
 
 import { initialFormState, trailerInformationForm } from './formDefinitions'
-import { updateTrailerMutation } from './queries'
+import { updateTrailerDisabled } from './queries'
 
 export default React.memo(function TrailerInformation({
   trailer,
   setEditIsOn,
-  updateMutation = updateTrailerMutation
+  updateMutation = updateTrailerDisabled
 }: {
   trailer: Trailer
   setEditIsOn?: (value: boolean) => void
-  updateMutation: MutationDescription<UpdateTrailerRequest, void>
+  updateMutation?: MutationDescription<UpdateTrailerRequest, void>
 }) {
+  const editDisabled = updateMutation === updateTrailerDisabled
   const i18n = useTranslation()
   const [editMode, setEditMode] = React.useState(false)
   const { mutateAsync: updateTrailer, isPending } = useMutation(updateMutation)
@@ -52,7 +53,7 @@ export default React.memo(function TrailerInformation({
           <h4>Trailerin tiedot</h4>
         </Column>
         <Column isNarrow toRight>
-          {editMode ? null : (
+          {editMode || editDisabled ? null : (
             <EditLink action={() => changeEditMode(true)}>
               Muokkaa trailerin tietoja
             </EditLink>

--- a/frontend/src/citizen-frontend/components/trailer/queries.ts
+++ b/frontend/src/citizen-frontend/components/trailer/queries.ts
@@ -1,6 +1,8 @@
-import { updateTrailer } from 'citizen-frontend/api-clients/trailer'
-import { mutation } from 'lib-common/query'
+import { UpdateTrailerRequest } from 'citizen-frontend/api-clients/trailer'
 
-export const updateTrailerMutation = mutation({
-  api: updateTrailer
-})
+import { createMutationDisabledDefault } from '../util'
+
+export const updateTrailerDisabled = createMutationDisabledDefault<
+  UpdateTrailerRequest,
+  void
+>()

--- a/frontend/src/citizen-frontend/components/util.ts
+++ b/frontend/src/citizen-frontend/components/util.ts
@@ -1,0 +1,11 @@
+import { MutationDescription } from 'lib-common/query'
+
+export const createMutationDisabledDefault = <
+  TArg,
+  TData
+>(): MutationDescription<TArg, TData> => {
+  return { api: (_arg: TArg) => Promise.resolve() } as MutationDescription<
+    TArg,
+    TData
+  >
+}

--- a/frontend/src/citizen-frontend/organization/OrganizationPage.tsx
+++ b/frontend/src/citizen-frontend/organization/OrganizationPage.tsx
@@ -21,7 +21,8 @@ import {
   citizenOrganizationQuery,
   deleteOrganizationBoatMutation,
   terminateOrganizationReservationMutation,
-  updateOrganizationBoatMutation
+  updateOrganizationBoatMutation,
+  updateOrganizationTrailerMutation
 } from './queries'
 
 export default function OrganizationPage() {
@@ -74,6 +75,7 @@ const Content = React.memo(function Content({
                 <Reservations
                   reservations={loadedActiveReservations}
                   terminateMutation={terminateOrganizationReservationMutation}
+                  updateTrailerMutation={updateOrganizationTrailerMutation}
                 />
                 <Boats
                   boats={boats}


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/espoon-voltti/vekkuli/pull/716 where updating organization trailer was using updateCitizenTrailerMutation instead of the updateOrganizationTrailerMutation, so it was not invalidating organization related queries. This bug was not caught by E2E tests because the data was not invalidated after the update, so the form retained its edited state correctly. It was only visible when navigating away and then back to the page.

E2E tests were not improved in this commit because this issue is systematic across all tests and requires further consideration.

Also changes how shared components handle missing mutation props to support some operation being disabled.