### PR TITLE
Link to frontpage

### DIFF
--- a/frontend/src/citizen-frontend/layout/Navigation.tsx
+++ b/frontend/src/citizen-frontend/layout/Navigation.tsx
@@ -11,7 +11,7 @@ import Menu from './Menu'
 export default React.memo(function Navigation() {
   const i18n = useTranslation()
   return (
-    <nav role="navigation" aria-label="main navigation">
+    <nav role="navigation" aria-label={i18n.header.mainNavigation}>
       <div className="nav-row">
         <div className="columns">
           <Link to="/" className="link" aria-label={i18n.header.goToHomepage}>

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
@@ -120,7 +120,8 @@ const en: Translations = {
     closeMenu: 'Close menu',
     goToHomepage: 'Go to homepage',
     goToMainContent: 'Skip to main content',
-    selectLanguage: 'Select language'
+    selectLanguage: 'Select language',
+    mainNavigation: 'Main navigation'
   },
   components: componentTranslations,
   reservation: {

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
@@ -119,7 +119,8 @@ export default {
     closeMenu: 'Sulje valikko',
     goToHomepage: 'Siirry etusivulle',
     goToMainContent: 'Siirry pääsisältöön',
-    selectLanguage: 'Valitse kieli'
+    selectLanguage: 'Valitse kieli',
+    mainNavigation: 'Päänavigaatio'
   },
   components: componentTranslations,
   reservation: {

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
@@ -120,7 +120,8 @@ const sv: Translations = {
     closeMenu: 'Stäng menyn',
     goToHomepage: 'Gå till hemsidan',
     goToMainContent: 'Hoppa till innehållet',
-    selectLanguage: 'Välj språk'
+    selectLanguage: 'Välj språk',
+    mainNavigation: 'Huvudnavigering'
   },
   components: componentTranslations,
   reservation: {


### PR DESCRIPTION
Saavutettavuus/suositus-korjaukset

Etu/kotisivulle pääsy ilman urlin muokkaamista ei ollut mahdollista.

Päänavigaatiossa oli kovakoodattu "main navigation".