### PR TITLE
Language change in form component labels for SearchPage

### DIFF
--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchPage.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchPage.tsx
@@ -1,6 +1,6 @@
 import { Loader } from 'lib-components/Loader'
 import { Column, Columns, Container, MainSection } from 'lib-components/dom'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import { AuthContext } from 'citizen-frontend/auth/state'
 import { useTranslation } from 'citizen-frontend/localization'
@@ -20,6 +20,7 @@ import SearchFilters from './SearchFilters'
 import SearchResult from './SearchResults'
 import {
   initialFormState,
+  onLanguageChange,
   SearchFormBranches,
   searchFreeSpacesForm
 } from './formDefinitions'
@@ -64,6 +65,11 @@ export default React.memo(function SearchPage() {
       }
     }
   )
+
+  useEffect(() => {
+    onLanguageChange(bind, i18n)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [i18n])
 
   const [isLoginModalOpen, setIsLoginModalOpen] = React.useState(false)
 

--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/formDefinitions.ts
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/formDefinitions.ts
@@ -18,6 +18,7 @@ import {
   union,
   value
 } from 'lib-common/form/form'
+import { BoundForm } from 'lib-common/form/hooks'
 import { OutputOf, StateOf } from 'lib-common/form/types'
 import { Translations } from 'lib-customizations/vekkuli/citizen'
 
@@ -113,6 +114,100 @@ export function initialFormState(
     ),
     boatSpaceUnionCache: initialUnionCacheFormState(i18n, storedSearchState)
   }
+}
+
+function mapOptionsWithTranslatedLabels<T extends { value: string }>(
+  options: T[],
+  translationPath: Record<string, string>
+): T[] {
+  return options.map((option) => ({
+    ...option,
+    label: translationPath[option.value]
+  }))
+}
+
+/**
+ * Form component (RadioField, SelectField, CheckBoxField) option labels
+ * get entered into the form as translated strings.
+ * When the language changes, the strings do not get updated automatically.
+ * This applies also to the union cache that is utilized when switching between
+ * form branches.
+ */
+export function onLanguageChange(
+  bind: BoundForm<SearchForm>,
+  i18n: Translations
+) {
+  bind.update((prev) => ({
+    ...prev,
+    boatSpaceType: {
+      ...prev.boatSpaceType,
+      options: prev.boatSpaceType.options.map((option) => {
+        return {
+          ...option,
+          label: i18n.boatSpace.boatSpaceType[option.value].label,
+          info: i18n.boatSpace.boatSpaceType[option.value].info
+        }
+      })
+    },
+    boatSpaceUnionForm: {
+      ...prev.boatSpaceUnionForm,
+      state: {
+        ...prev.boatSpaceUnionForm.state,
+        amenities: {
+          ...prev.boatSpaceUnionForm.state.amenities,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionForm.state.amenities.options,
+            i18n.boatSpace.amenities
+          )
+        },
+        boatType: {
+          ...prev.boatSpaceUnionForm.state.boatType,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionForm.state.boatType.options,
+            i18n.boatSpace.boatType
+          )
+        },
+        storageAmenity: {
+          ...prev.boatSpaceUnionForm.state.storageAmenity,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionForm.state.storageAmenity.options,
+            i18n.boatSpace.amenities
+          )
+        }
+      }
+    },
+    // Slip and Storage are currently the only form branches that have translated labels
+    boatSpaceUnionCache: {
+      ...prev.boatSpaceUnionCache,
+      Slip: {
+        ...prev.boatSpaceUnionCache.Slip,
+        amenities: {
+          ...prev.boatSpaceUnionCache.Slip.amenities,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionCache.Slip.amenities.options,
+            i18n.boatSpace.amenities
+          )
+        },
+        boatType: {
+          ...prev.boatSpaceUnionCache.Slip.boatType,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionCache.Slip.boatType.options,
+            i18n.boatSpace.boatType
+          )
+        }
+      },
+      Storage: {
+        ...prev.boatSpaceUnionCache.Storage,
+        storageAmenity: {
+          ...prev.boatSpaceUnionCache.Storage.storageAmenity,
+          options: mapOptionsWithTranslatedLabels(
+            prev.boatSpaceUnionCache.Storage.storageAmenity.options,
+            i18n.boatSpace.amenities
+          )
+        }
+      }
+    }
+  }))
 }
 
 export type SearchFormBranches = BoatSpaceType


### PR DESCRIPTION

<img width="477" alt="Screenshot 2025-02-06 at 12 19 49" src="https://github.com/user-attachments/assets/067a8ae9-6955-4259-bfd0-eaa7b8459141" />


Korjaus formin kenttien vaihtoehtojen käännösten näyttämiseen - kun kieltä vaihtaa, "formi-frameworkin" statessa on ruudulla näytettävät tekstit käännettyinä stringeinä. Päivitetään useFormin updatella labelit staten eri osiin. 



**_Ennen muutosta:_**

https://github.com/user-attachments/assets/cdf41417-c861-4111-a92e-92af136fdfa4



**_Muutoksen jälkeen:_**


https://github.com/user-attachments/assets/31e9fe74-8f6e-4179-8bc1-eea632a72215

