### PR TITLE
Billing address for organizations in invoice email.

### DIFF
--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/EmailSendingTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/EmailSendingTest.kt
@@ -23,11 +23,12 @@ open class EmailSendingTest : PlaywrightTest() {
 
     protected fun assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice(
         emailAddress: String? = null,
+        invoiceAddress: String,
         sendAndAssertSendCount: Boolean? = null
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin laituripaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen $invoiceAddress",
         sendAndAssertSendCount
     )
 
@@ -48,7 +49,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertFixedTermReservationEmail(
         emailAddress,
         "Espoon kaupungin laituripaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         endDate,
         sendAndAssertSendCount
     )
@@ -93,7 +94,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin säilytyspaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -114,7 +115,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertFixedTermReservationEmail(
         emailAddress,
         "Espoon kaupungin säilytyspaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         endDate,
         sendAndAssertSendCount
     )
@@ -147,7 +148,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin traileripaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -168,7 +169,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertFixedTermReservationEmail(
         emailAddress,
         "Espoon kaupungin traileripaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         endDate,
         sendAndAssertSendCount
     )
@@ -213,7 +214,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin talvipaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -234,7 +235,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertFixedTermReservationEmail(
         emailAddress,
         "Espoon kaupungin talvipaikkavaraus",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         endDate,
         sendAndAssertSendCount
     )
@@ -268,7 +269,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin laituripaikkavarauksen jatkaminen",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -298,7 +299,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin säilytyspaikkavarauksen jatkaminen",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -328,7 +329,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin talvipaikkavarauksen jatkaminen",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 
@@ -358,7 +359,7 @@ open class EmailSendingTest : PlaywrightTest() {
     ) = assertIndefiniteReservationEmail(
         emailAddress,
         "Espoon kaupungin traileripaikkavarauksen jatkaminen",
-        "Sinulle on lähetetty lasku osoitteeseen",
+        "Lasku lähetetään osoitteeseen",
         sendAndAssertSendCount
     )
 

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveAndTerminateFlowTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveAndTerminateFlowTest.kt
@@ -64,7 +64,7 @@ class ReserveAndTerminateFlowTest : ReserveTest() {
         reserveBoatSpacePage.revealB314BoatSpace()
         assertThat(reserveBoatSpacePage.reserveTableB314Row).not().isVisible()
 
-        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi")
+        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi", "Katu 1, 00100")
         SendEmailServiceMock.resetEmails()
 
         // Terminate the reservation

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveBoatSpaceAsEmployeeTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/employee/ReserveBoatSpaceAsEmployeeTest.kt
@@ -153,7 +153,7 @@ class ReserveBoatSpaceAsEmployeeTest : ReserveTest() {
             citizenDetailsPage.memoNavi.click()
             assertThat(page.getByText("Varauksen tila: Maksettu 2024-04-22: 100000")).isVisible()
 
-            assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice()
+            assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice(invoiceAddress = "Test street 1, 12345")
             citizenDetailsPage.paymentsNavi.click()
 
             page.waitForCondition { citizenDetailsPage.paymentsTable.textContent().contains("Maksettu") }
@@ -877,7 +877,7 @@ class ReserveBoatSpaceAsEmployeeTest : ReserveTest() {
         messageService.sendScheduledEmails()
         assertEquals(1, SendEmailServiceMock.emails.size)
 
-        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi")
+        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi", "Katu 1, 00100")
     }
 
     @Test
@@ -927,7 +927,7 @@ class ReserveBoatSpaceAsEmployeeTest : ReserveTest() {
         // Check that the reservation is visible in the list
         assertThat(page.getByText(place)).isVisible()
 
-        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("turvald@kieltoinen.fi")
+        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("turvald@kieltoinen.fi", "*salainen*")
     }
 
     @Test
@@ -998,11 +998,19 @@ class ReserveBoatSpaceAsEmployeeTest : ReserveTest() {
         formPage.orgBusinessIdInput.fill("1234567-8")
         formPage.orgPhoneNumberInput.fill("123456789")
         formPage.orgEmailInput.fill("foo@bar.com")
+        formPage.orgAddressInput.fill("Organisaation käyntiosoite")
+        formPage.orgPostalCodeInput.fill("03300")
+        formPage.orgCityInput.fill("Espoo")
 
-        formPage.orgBillingNameInput.fill("Billing Name")
-        formPage.orgBillingAddressInput.fill("Billing Name")
-        formPage.orgBillingPostalCodeInput.fill("12345")
-        formPage.orgBillingCityInput.fill("12345")
+        val orgBillingName = "Laskun vastaanottaja"
+        val orgBillingAddress = "Laskutusosoite 12"
+        val orgBillingPostalCode = "02320"
+        val orgBillingCity = "Espoo"
+
+        formPage.orgBillingNameInput.fill(orgBillingName)
+        formPage.orgBillingAddressInput.fill(orgBillingAddress)
+        formPage.orgBillingPostalCodeInput.fill(orgBillingPostalCode)
+        formPage.orgBillingCityInput.fill(orgBillingCity)
 
         formPage.depthInput.fill("1.5")
         formPage.depthInput.blur()
@@ -1035,11 +1043,12 @@ class ReserveBoatSpaceAsEmployeeTest : ReserveTest() {
         reservationListPage.navigateTo()
         assertThat(reservationListPage.header).isVisible()
 
+        val expectedInvoiceAddress = "$orgBillingName/$orgBillingAddress,$orgBillingPostalCode,$orgBillingCity"
         messageService.sendScheduledEmails()
         // Email is sent to both organization representative and the reserver
         assertEquals(2, SendEmailServiceMock.emails.size)
-        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("foo@bar.com", false)
-        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi", false)
+        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("foo@bar.com", expectedInvoiceAddress, false)
+        assertEmailIsSentOfEmployeesIndefiniteSlipReservationWithInvoice("mikko.virtanen@noreplytest.fi", expectedInvoiceAddress, false)
     }
 
     @Test

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/employee/BoatSpaceFormPage.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/employee/BoatSpaceFormPage.kt
@@ -72,6 +72,9 @@ class BoatSpaceFormPage(
     val orgNameInput = page.getByTestId("orgName")
     val orgBusinessIdInput = page.getByTestId("orgBusinessId")
     val orgPhoneNumberInput = page.getByTestId("orgPhone")
+    val orgAddressInput = page.getByTestId("orgAddress")
+    val orgPostalCodeInput = page.getByTestId("orgPostalCode")
+    val orgCityInput = page.getByTestId("orgCity")
     val orgEmailInput = page.getByTestId("orgEmail")
 
     val orgBillingNameInput = page.getByTestId("orgBillingName")

--- a/service/src/e2eTest/resources/seed.sql
+++ b/service/src/e2eTest/resources/seed.sql
@@ -631,7 +631,7 @@ venepaikat@espoo.fi'),
 
 Sinulle on varattu Espoon kaupungin {{placeTypeFi}} {{name}}.
 
-Sinulle on lähetetty lasku osoitteeseen {{invoiceAddress}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi. Maksun saavuttua tilillemme lähetämme sähköpostilla lisätietoa laiturin portin avaimesta sekä kausitarran postitse.
+Lasku lähetetään osoitteeseen {{invoiceAddressFi}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi. Maksun saavuttua tilillemme lähetämme sähköpostilla lisätietoa laiturin portin avaimesta sekä kausitarran postitse.
 
 Vuokralainen:
 {{reserverName}}
@@ -664,7 +664,7 @@ Hej kund,
 
 Du har reserverat en {{placeTypeSv}} {{name}} från Esbo stad.
 
-En faktura har skickats till adressen {{invoiceAddress}}. För att bekräfta bokningen, betala platsen innan förfallodatumet. Om betalningen uteblir annulleras bokningen och platsen blir tillgänglig för andra. När betalningen har mottagits på vårt konto skickar vi ytterligare information om bryggportens nyckel via e-post samt säsongsetiketten per post.
+Fakturan skickas till {{invoiceAddressSv}}. För att bekräfta bokningen, betala platsen innan förfallodatumet. Om betalningen uteblir annulleras bokningen och platsen blir tillgänglig för andra. När betalningen har mottagits på vårt konto skickar vi ytterligare information om bryggportens nyckel via e-post samt säsongsetiketten per post.
 
 Hyresgäst:
 {{reserverName}}
@@ -697,7 +697,7 @@ Dear customer,
 
 You have reserved a {{placeTypeEn}} {{name}} from the City of Espoo.
 
-An invoice has been sent to {{invoiceAddress}}. To confirm your booking, please pay for the spot before the due date. If unpaid, the booking will be canceled and made available for others. Once payment is received, we will send additional information about the dock gate key via email and the season sticker by mail.
+The invoice will be sent to {{invoiceAddressEn}}. To confirm your booking, please pay for the spot before the due date. If unpaid, the booking will be canceled and made available for others. Once payment is received, we will send additional information about the dock gate key via email and the season sticker by mail.
 
 Tenant:
 {{reserverName}}
@@ -901,7 +901,7 @@ venepaikat@espoo.fi'),
 
 Varaamasi Espoon kaupungin {{placeTypeFi}} on jatkettu uudelle kaudelle.
 
-Sinulle on lähetetty lasku osoitteeseen {{invoiceAddress}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi.
+Lasku lähetetään osoitteeseen {{invoiceAddressFi}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi.
 
 Vuokralainen:
 {{reserverName}}
@@ -929,7 +929,7 @@ Hej kund,
 
 Din bokning av {{placeTypeSv}} har förlängts för en ny säsong.
 
-En faktura har skickats till adressen {{invoiceAddress}}. För att bekräfta bokningen, vänligen betala platsen innan förfallodatumet. En obetald plats sägs upp och blir tillgänglig för andra.
+Fakturan skickas till {{invoiceAddressSv}}. För att bekräfta bokningen, vänligen betala platsen innan förfallodatumet. En obetald plats sägs upp och blir tillgänglig för andra.
 
 Hyresgäst:
 {{reserverName}}
@@ -957,7 +957,7 @@ Dear customer,
 
 Your reservation for {{placeTypeEn}} has been extended for a new season.
 
-An invoice has been sent to {{invoiceAddress}}. To confirm your reservation, please pay for the spot before the due date. An unpaid spot will be canceled and made available for others.
+The invoice will be sent to {{invoiceAddressEn}}. To confirm your reservation, please pay for the spot before the due date. An unpaid spot will be canceled and made available for others.
 
 Tenant:
 {{reserverName}}
@@ -1472,8 +1472,12 @@ VALUES
   ('f5d377ea-5547-11ef-a1c7-7f2b94cf9afd', '150499-911U', 'Leo', 'Korhonen'),
   ('509edb00-5549-11ef-a1c7-776e76028a49', '031298-988S', 'Olivia', 'Virtanen'),
   ('1128bd21-fbbc-4e9a-8658-dc2044a64a58', '290991-993F', 'Marko', 'Kuusinen'),
-  ('82722a75-793a-4cbe-a3d9-a3043f2f5731', '111275-180K', 'Jorma', 'Pulkkinen'),
-  ('6a7b1b37-ace5-4992-878b-1fa0cd52e4e7', '250695-7378', 'Turvald', 'Kieltoinen')
+  ('82722a75-793a-4cbe-a3d9-a3043f2f5731', '111275-180K', 'Jorma', 'Pulkkinen')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO citizen (id, national_id, first_name, last_name, data_protection)
+VALUES
+    ('6a7b1b37-ace5-4992-878b-1fa0cd52e4e7', '250695-7378', 'Turvald', 'Kieltoinen', true)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO organization (id, business_id, billing_name, billing_street_address, billing_postal_code, billing_post_office)

--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/BoatSpaceSwitchTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/BoatSpaceSwitchTests.kt
@@ -99,7 +99,8 @@ class BoatSpaceSwitchTests : IntegrationTestBase() {
                 discountPercentage = 10,
                 nationalId = "123456-789A",
                 firstName = "Mikko",
-                lastName = "Testinen"
+                lastName = "Testinen",
+                dataProtection = false
             )
 
         // Let's not tes

--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReservationAvailabilityTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReservationAvailabilityTests.kt
@@ -64,7 +64,8 @@ class ReservationAvailabilityTests : IntegrationTestBase() {
                 discountPercentage = 10,
                 nationalId = "123456-789A",
                 firstName = "Mikko",
-                lastName = "Testinen"
+                lastName = "Testinen",
+                dataProtection = false
             )
 
         // Let's not tes

--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReserverServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReserverServiceIntegrationTests.kt
@@ -71,7 +71,8 @@ class ReserverServiceIntegrationTests : IntegrationTestBase() {
                 postOfficeSv = "Esbo",
                 streetAddressSv = "",
                 espooRulesApplied = false,
-                discountPercentage = 0
+                discountPercentage = 0,
+                dataProtection = false
             )
         val updatedCitizen =
             reserverService.updateCitizen(
@@ -115,7 +116,8 @@ class ReserverServiceIntegrationTests : IntegrationTestBase() {
                 postOfficeSv = "Esbo",
                 streetAddressSv = "",
                 espooRulesApplied = false,
-                discountPercentage = 0
+                discountPercentage = 0,
+                dataProtection = false
             )
         reserverService.updateCitizen(
             UpdateCitizenParams(

--- a/service/src/main/kotlin/fi/espoo/vekkuli/domain/Citizen.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/domain/Citizen.kt
@@ -42,6 +42,7 @@ data class CitizenWithDetails(
     val nationalId: String,
     val firstName: String,
     val lastName: String,
+    val dataProtection: Boolean
 ) {
     val birthday: String
         get() = getBirthDateFromSSN(nationalId)

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiOrganizationRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiOrganizationRepository.kt
@@ -35,7 +35,7 @@ class JdbiOrganizationRepository(
             handle
                 .createQuery(
                     """
-                    SELECT c.national_id, c.first_name, c.last_name, r.*, m.name as municipality_name 
+                    SELECT c.national_id, c.first_name, c.last_name, c.data_protection, r.*, m.name as municipality_name 
                     FROM organization_member om
                     JOIN citizen c on om.member_id = c.id
                     JOIN reserver r on om.member_id = r.id

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiReserverRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiReserverRepository.kt
@@ -63,7 +63,7 @@ class JdbiReserverRepository(
             handle
                 .createQuery(
                     """    
-                    SELECT c.first_name, c.last_name, c.national_id, r.*, m.name as municipality_name
+                    SELECT c.first_name, c.last_name, c.national_id, c.data_protection, r.*, m.name as municipality_name
                     FROM citizen c
                     JOIN reserver r ON r.id = c.id
                     JOIN municipality m ON r.municipality_code = m.code
@@ -79,7 +79,7 @@ class JdbiReserverRepository(
             handle
                 .createQuery(
                     """    
-                    SELECT c.first_name, c.last_name, c.national_id, r.*, m.name as municipality_name
+                    SELECT c.first_name, c.last_name, c.national_id, c.data_protection, r.*, m.name as municipality_name
                     FROM citizen c
                     JOIN reserver r ON r.id = c.id
                     JOIN municipality m ON r.municipality_code = m.code
@@ -97,7 +97,7 @@ class JdbiReserverRepository(
             val query =
                 handle.createQuery(
                     """
-                    SELECT c.first_name, c.last_name, c.national_id, r.*, m.name as municipality_name 
+                    SELECT c.first_name, c.last_name, c.national_id, c.data_protection, r.*, m.name as municipality_name 
                     FROM citizen c
                     JOIN reserver r ON r.id = c.id
                     JOIN municipality m ON r.municipality_code = m.code

--- a/service/src/main/resources/db/migration/V072__update_employee_made_reservation_with_invoice_email.sql
+++ b/service/src/main/resources/db/migration/V072__update_employee_made_reservation_with_invoice_email.sql
@@ -1,0 +1,182 @@
+-- noinspection SqlWithoutWhereForFile
+UPDATE email_template SET subject = 'Espoon kaupungin {{placeTypeFi}}varaus',
+                          body = E'Hyvä asiakas,
+
+Sinulle on varattu Espoon kaupungin {{placeTypeFi}} {{name}}.
+
+Lasku lähetetään osoitteeseen {{invoiceAddressFi}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi. Maksun saavuttua tilillemme lähetämme sähköpostilla lisätietoa laiturin portin avaimesta sekä kausitarran postitse.
+
+Vuokralainen:
+{{reserverName}}
+
+Paikan tiedot:
+{{harborAddressFi}}
+Paikan nimi: {{name}}
+Paikan leveys: {{width}}
+Paikan pituus: {{length}}
+Paikan varuste/säilytystapa: {{amenityFi}}
+
+Varauksesi on voimassa {{endDateFi}}.
+
+Jos varasit laituripaikan, saat myöhemmin postissa kausitarran ja satamakartan, jossa avainkoodi laiturin portin avaimen teettämistä varten (Otsolahden F-laiturille ei ole porttia). Kausitarra tulee kiinnittää näkyvälle paikalle veneeseen tai jos varasit talvi- tai säilytyspaikan, suojatelttaan, traileriin tai pukkiin.
+
+Jos varasit säilytyspaikan Ämmäsmäeltä:
+Ämmäsmäen kulkulätkän noudosta tulee sopia ennakkoon soittamalla numeroon 050 3209 681 arkisin kello 9-13. Kulkulätkä noudetaan Suomenojan satamasta (Hylkeenpyytäjäntie 9) maksukuittia näyttämällä.
+
+Hallinnoi varauksiasi, veneitäsi ja omia tietojasi helposti osoitteessa https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Venesatamia koskevat sopimusehdot ja säännöt sekä muuta infoa löydät osoitteesta https://www.espoo.fi/fi/liikunta-ja-luonto/veneily.
+
+Terveisin
+Merelliset ulkoilupalvelut
+venepaikat@espoo.fi
+
+**************************************************
+
+Hej kund,
+
+Du har reserverat en {{placeTypeSv}} {{name}} från Esbo stad.
+
+Fakturan skickas till {{invoiceAddressSv}}. För att bekräfta bokningen, betala platsen innan förfallodatumet. Om betalningen uteblir annulleras bokningen och platsen blir tillgänglig för andra. När betalningen har mottagits på vårt konto skickar vi ytterligare information om bryggportens nyckel via e-post samt säsongsetiketten per post.
+
+Hyresgäst:
+{{reserverName}}
+
+Platsinformation:
+{{harborAddressSv}}
+Platsens namn: {{name}}
+Platsens bredd: {{width}}
+Platsens längd: {{length}}
+Platsens utrustning/förvaringssätt: {{amenitySv}}
+
+Bokningen gäller till {{endDateSv}}.
+
+Om du har bokat en bryggplats får du senare en säsongsetikett och en hamnkarta per post, där du hittar en nyckelkod för att skapa en nyckel till bryggporten (det finns ingen port vid Otsolahti F-bryggan). Säsongsetiketten måste fästas synligt på båten eller, om du har bokat en vinter- eller förvaringsplats, på skyddstältet, trailern eller stöttan.
+
+Om du har bokat en förvaringsplats i Ämmäsmäki:
+Uthämtning av tillträdesbrickan ska avtalas i förväg genom att ringa 050 3209 681 vardagar mellan 9-13. Tillträdesbrickan hämtas från Finno hamn (Hylkeenpyytäjäntie 9) genom att visa kvittot.
+
+Hantera dina bokningar, båtar och personuppgifter enkelt på https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Regler och villkor för båthamnar samt annan information hittar du på https://www.espoo.fi/sv/idrott-motion-och-natur/batliv.
+
+Vänliga hälsningar
+Havsnära friluftstjänster
+venepaikat@espoo.fi
+
+**************************************************
+
+Dear customer,
+
+You have reserved a {{placeTypeEn}} {{name}} from the City of Espoo.
+
+The invoice will be sent to {{invoiceAddressEn}}. To confirm your booking, please pay for the spot before the due date. If unpaid, the booking will be canceled and made available for others. Once payment is received, we will send additional information about the dock gate key via email and the season sticker by mail.
+
+Tenant:
+{{reserverName}}
+
+Location details:
+{{harborAddressEn}}
+Name: {{name}}
+Width: {{width}}
+Length: {{length}}
+Amenities/storage type: {{amenityEn}}
+
+Your reservation is valid until {{endDateEn}}.
+
+If you reserved a dock space, you will receive a season sticker and a harbor map by mail later, containing the key code needed for making a key for the dock gate (Otsolahti F-dock has no gate). The season sticker must be placed visibly on the boat, or if you reserved a winter or storage space, on the protective tent, trailer, or stand.
+
+If you reserved a storage space in Ämmäsmäki:
+The pickup of the access badge must be arranged in advance by calling 050 3209 681 on weekdays between 9-13. The badge is picked up from the Suomenoja harbor (Hylkeenpyytäjäntie 9) by showing the payment receipt.
+
+Manage your reservations, boats, and personal details easily at https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Terms and conditions for boat harbors and additional information can be found at https://www.espoo.fi/en/sports-and-nature/boating.
+
+Best regards
+Maritime Outdoor Services
+venepaikat@espoo.fi'
+WHERE id = 'reservation_created_by_employee';
+
+UPDATE email_template SET body = E'Hyvä asiakas,
+
+Varaamasi Espoon kaupungin {{placeTypeFi}} on jatkettu uudelle kaudelle.
+
+Lasku lähetetään osoitteeseen {{invoiceAddressFi}}. Vahvistaaksesi varauksen, maksa paikka eräpäivään mennessä. Maksamaton paikka irtisanoutuu ja se vapautuu muiden varattavaksi.
+
+Vuokralainen:
+{{reserverName}}
+
+Paikan tiedot:
+{{harborAddressFi}}
+Paikan nimi: {{name}}
+Paikan leveys: {{width}}
+Paikan pituus: {{length}}
+Paikan varuste/säilytystapa: {{amenityFi}}
+
+Varauksesi on voimassa {{endDateFi}}.
+
+Hallinnoi varauksiasi, veneitäsi ja omia tietojasi helposti osoitteessa https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Venesatamia koskevat sopimusehdot ja säännöt sekä muuta infoa löydät osoitteesta https://www.espoo.fi/fi/liikunta-ja-luonto/veneily.
+
+Terveisin
+Merelliset ulkoilupalvelut
+venepaikat@espoo.fi
+
+**************************************************
+
+Hej kund,
+
+Din bokning av {{placeTypeSv}} har förlängts för en ny säsong.
+
+Fakturan skickas till {{invoiceAddressSv}}. För att bekräfta bokningen, vänligen betala platsen innan förfallodatumet. En obetald plats sägs upp och blir tillgänglig för andra.
+
+Hyresgäst:
+{{reserverName}}
+
+Platsinformation:
+{{harborAddressSv}}
+Platsens namn: {{name}}
+Platsens bredd: {{width}}
+Platsens längd: {{length}}
+Platsens utrustning/förvaringssätt: {{amenitySv}}
+
+Din bokning är giltig till {{endDateSv}}.
+
+Hantera dina bokningar, båtar och personuppgifter enkelt på https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Regler och villkor för båthamnar samt annan information hittar du på https://www.espoo.fi/sv/idrott-motion-och-natur/batliv.
+
+Vänliga hälsningar
+Havsnära friluftstjänster
+venepaikat@espoo.fi
+
+**************************************************
+
+Dear customer,
+
+Your reservation for {{placeTypeEn}} has been extended for a new season.
+
+The invoice will be sent to {{invoiceAddressEn}}. To confirm your reservation, please pay for the spot before the due date. An unpaid spot will be canceled and made available for others.
+
+Tenant:
+{{reserverName}}
+
+Location details:
+{{harborAddressEn}}
+Name: {{name}}
+Width: {{width}}
+Length: {{length}}
+Amenities/storage type: {{amenityEn}}
+
+Your reservation is valid until {{endDateEn}}.
+
+Manage your reservations, boats, and personal details easily at https://varaukset.espoo.fi/kuntalainen/omat-tiedot.
+
+Terms and conditions for boat harbors and additional information can be found at https://www.espoo.fi/en/sports-and-nature/boating.
+
+Best regards
+Maritime Outdoor Services
+venepaikat@espoo.fi'
+WHERE id='reservation_renewed_by_employee';

--- a/service/src/main/resources/locales/messages.properties
+++ b/service/src/main/resources/locales/messages.properties
@@ -516,6 +516,7 @@ boatSpaceReservation.email.types.Winter=winter storage
 boatSpaceReservation.email.reserver=\n\nReserver: {0}
 boatSpaceReservation.email.harborAddress=Harbor address: {0}
 boatSpaceReservation.email.storagePlaceAddress=Storage area address: {0}
+boatSpaceReservation.email.dataProtectionAddress=*secret*
 boatSpaceList.title.harbor=Harbor
 boatSpaceList.title.place=Place
 boatSpaceList.title.type=Type

--- a/service/src/main/resources/locales/messages_fi.properties
+++ b/service/src/main/resources/locales/messages_fi.properties
@@ -516,6 +516,7 @@ boatSpaceReservation.email.types.Winter=talvipaikka
 boatSpaceReservation.email.reserver=\n\nVaraaja: {0}
 boatSpaceReservation.email.harborAddress=Sataman osoite: {0}
 boatSpaceReservation.email.storagePlaceAddress=Säilytysalueen osoite: {0}
+boatSpaceReservation.email.dataProtectionAddress=*salainen*
 boatSpaceList.title.harbor=Satama
 boatSpaceList.title.place=Paikka
 boatSpaceList.title.type=Paikan tyyppi

--- a/service/src/main/resources/locales/messages_sv.properties
+++ b/service/src/main/resources/locales/messages_sv.properties
@@ -511,4 +511,5 @@ boatSpaceReservation.email.types.Winter=vinterplats
 boatSpaceReservation.email.reserver=\n\nBokare: {0}
 boatSpaceReservation.email.harborAddress=Hamnadress: {0}
 boatSpaceReservation.email.storagePlaceAddress=Förvaringsområdets adress: {0}
+boatSpaceReservation.email.dataProtectionAddress=*hemlig*
 


### PR DESCRIPTION
Use billing address in invoice emails for organizations. 
For data protected users, don't show address (could be unknown) but use placeholder word *secret* instead.