### PR TITLE
Hide buoy boat space size for citizens

### DIFF
--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/ResultRow.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/ResultRow.tsx
@@ -19,9 +19,7 @@ export const ResultRow = React.memo(function ResultRow({
   const i18n = useTranslation()
   return (
     <tr>
-      <td>
-        <SpaceSize size={space.size} />
-      </td>
+      <td>{space.amenity !== 'Buoy' && <SpaceSize size={space.size} />}</td>
       <td>{i18n.boatSpace.amenities[space.amenity]} </td>
       <td>
         <PriceFormat price={space.price} />

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/citizen/ReserveBoatSpaceTest.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/citizen/ReserveBoatSpaceTest.kt
@@ -1306,6 +1306,33 @@ class ReserveBoatSpaceTest : ReserveTest() {
     }
 
     @Test
+    fun `Buoy boat spaces are ordered last and do not display size`() {
+        CitizenHomePage(page).loginAsEspooCitizenWithoutReservations()
+
+        val reserveBoatSpacePage = ReserveBoatSpacePage(page)
+        val filterSection = reserveBoatSpacePage.getFilterSection()
+        val slipFilterSection = filterSection.getSlipFilterSection()
+        val searchResultsSection = reserveBoatSpacePage.getSearchResultsSection()
+
+        reserveBoatSpacePage.navigateToPage()
+        filterSection.slipRadio.click()
+        slipFilterSection.boatTypeSelect.selectOption("Sailboat")
+        slipFilterSection.widthInput.fill("4")
+        slipFilterSection.lengthInput.fill("14")
+        slipFilterSection.suomenojaCheckbox.click()
+
+        searchResultsSection.showMoreToggle("Suomenoja").click()
+
+        val buoySpaceRowIndex = searchResultsSection.getReserveButtonPlacementByPlace("Suomenoja", "POIJU 001")
+        val referenceSpaceRowIndex = searchResultsSection.getReserveButtonPlacementByPlace("Suomenoja", "G 117")
+
+        assertTrue(referenceSpaceRowIndex < buoySpaceRowIndex, "Buoy boat spaces should be ordered last")
+
+        val buoySpaceRow = searchResultsSection.reserveRowByPlace("POIJU", "001")
+        assertThat(buoySpaceRow).not().containsText("1 000,00 x 1 000,00 m")
+    }
+
+    @Test
     fun `For a slip, a warning is shown if the boat size is not within the limits`() {
         CitizenHomePage(page).loginAsEspooCitizenWithoutReservations()
 

--- a/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/citizen/ReserveBoatSpacePage.kt
+++ b/service/src/e2eTest/kotlin/fi/espoo/vekkuli/pages/citizen/ReserveBoatSpacePage.kt
@@ -43,6 +43,7 @@ class ReserveBoatSpacePage(
         val amenityWalkBeamCheckbox = fields.getCheckbox("Kävelyaisa")
         val haukilahtiCheckbox = fields.getCheckbox("Haukilahti")
         val kivenlahtiCheckbox = fields.getCheckbox("Kivenlahti")
+        val suomenojaCheckbox = fields.getCheckbox("Suomenoja")
         val svinöCheckbox = fields.getCheckbox("Svinö")
     }
 
@@ -81,10 +82,12 @@ class ReserveBoatSpacePage(
         val b059ReserveButton = reserveButtonByPlace("B", "059")
         val b007ReserveButton = reserveButtonByPlace("B", "007")
 
+        fun showMoreToggle(harbor: String) = root.getByLabel("Näytä lisää: $harbor", Locator.GetByLabelOptions().setExact(true))
+
         internal fun reserveButtonByPlace(
             section: String,
             placeNumber: String,
-        ) = root.locator("tr:has-text('$section $placeNumber')").locator("button:has-text('Varaa')")
+        ) = reserveRowByPlace(section, placeNumber).locator("button:has-text('Varaa')")
 
         fun getReserveButtonPlacementByPlace(
             location: String,
@@ -94,6 +97,11 @@ class ReserveBoatSpacePage(
             val rows = location.locator("tr").all()
             return rows.indexOfFirst { row -> row.innerText().contains(place) }
         }
+
+        fun reserveRowByPlace(
+            section: String,
+            placeNumber: String
+        ) = root.locator("tr:has-text('$section $placeNumber')")
     }
 
     class ReserveModal(

--- a/service/src/e2eTest/resources/seed.sql
+++ b/service/src/e2eTest/resources/seed.sql
@@ -3947,7 +3947,8 @@ INSERT INTO boat_space (id, type, location_id, price_id, section, place_number, 
     ('2434', 'Slip', '7', '4', 'E', '64', 'WalkBeam', '380', '1000', 'none'),
     ('2435', 'Slip', '7', '4', 'E', '66', 'WalkBeam', '380', '1000', 'none'),
     ('2436', 'Slip', '7', '3', 'E', '68', 'WalkBeam', '320', '1000', 'none'),
-    ('2437', 'Slip', '7', '2', 'Ä', '1', 'Beam', '250', '500', 'none');
+    ('2437', 'Slip', '7', '2', 'Ä', '1', 'Beam', '250', '500', 'none'),
+    ('2438', 'Slip', '6', '5', 'POIJU', '1', 'Buoy', '100000', '100000', 'none');
 
 
 INSERT INTO trailer (registration_code, reserver_id, width_cm, length_cm)


### PR DESCRIPTION
Hides buoy boat space sizes in search result listing.

Buoy boat spaces have been forced last by changing their size to 1000x1000 m in migration.