### PR TITLE
Bridge height warning for search results

### DIFF
--- a/frontend/src/citizen-frontend/main.scss
+++ b/frontend/src/citizen-frontend/main.scss
@@ -455,6 +455,10 @@ body > .columns {
     border-color: $bulma-primary;
   }
 
+  &.is-warning {
+    border-color: $warning;
+  }
+
   &.is-error {
     border-color: $warning;
   }

--- a/frontend/src/citizen-frontend/reservation/components/InfoBox.tsx
+++ b/frontend/src/citizen-frontend/reservation/components/InfoBox.tsx
@@ -1,26 +1,33 @@
 import classNames from 'classnames'
 import React from 'react'
 
-import { BlueInfoCircle } from 'lib-icons'
+import { BlueInfoCircle, WarningExclamation } from 'lib-icons'
 
 type InfoBoxProps = {
   text: string
   fullWidth?: boolean
+  isWarning?: boolean
 }
 
 export const InfoBox = React.memo(function InfoBox({
   text,
-  fullWidth
+  fullWidth,
+  isWarning
 }: InfoBoxProps) {
-  const classes = classNames('message-box is-info column', {
-    'is-four-fifths': !fullWidth
+  const classes = classNames('message-box column', {
+    'is-four-fifths': !fullWidth,
+    [isWarning ? 'is-warning' : 'is-info']: true
   })
 
   return (
     <div className={classes}>
       <div className="column is-narrow">
         <span className="icon">
-          <BlueInfoCircle />
+          {isWarning ? (
+            <WarningExclamation isError={false} />
+          ) : (
+            <BlueInfoCircle />
+          )}
         </span>
       </div>
       <p className="column">{text}</p>

--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/BridgeHeightWarningBox.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/BridgeHeightWarningBox.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { Translations, useTranslation } from 'citizen-frontend/localization'
+import { InfoBox } from 'citizen-frontend/reservation/components/InfoBox'
+
+const BridgeHeightLimitedLocations = {
+  Laajalahti: 3,
+  Otsolahti: 4
+} as const
+
+const bridgeHeightLimitedLocationIds: number[] = Object.values(
+  BridgeHeightLimitedLocations
+)
+
+const getBridgeHeightWarningByLocationId = (
+  locationId: number,
+  i18n: Translations
+) => {
+  switch (locationId) {
+    case BridgeHeightLimitedLocations.Laajalahti:
+      return i18n.boatSpace.heightWarning.bridges('3,5')
+    case BridgeHeightLimitedLocations.Otsolahti:
+      return i18n.boatSpace.heightWarning.bridge('3,0')
+    default:
+      return ''
+  }
+}
+
+export const BridgeHeightWarningBox = React.memo(
+  function BridgeHeightWarningBox({ placeId }: { placeId: number }) {
+    const i18n = useTranslation()
+
+    if (!bridgeHeightLimitedLocationIds.includes(placeId)) {
+      return null
+    }
+
+    return (
+      <InfoBox
+        fullWidth
+        isWarning
+        text={getBridgeHeightWarningByLocationId(placeId, i18n)}
+      />
+    )
+  }
+)

--- a/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/ResultGroup.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/chooseBoatSpace/SearchResults/ResultGroup.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Place, Space } from 'citizen-frontend/api-types/free-spaces'
 import { useTranslation } from 'citizen-frontend/localization'
 
+import { BridgeHeightWarningBox } from './BridgeHeightWarningBox'
 import { ResultRow } from './ResultRow'
 import { ShowMore } from './ShowMore'
 
@@ -28,6 +29,7 @@ export const ResultGroup = React.memo(function ResultGroup({
       <div className="mb-m">
         <h3 className="subtitle harbor-header mb-s">{place.name}</h3>
         <div className="block mb-s">{place.address}</div>
+        <BridgeHeightWarningBox placeId={place.id} />
       </div>
       <table className="table search-results-table is-striped is-hoverable is-fullwidth">
         <thead>

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/en.tsx
@@ -542,7 +542,13 @@ const en: Translations = {
       Buck: 'Stand storage',
       BuckWithTent: 'Stand storage with protective tent'
     },
-    reserve: 'Reserve'
+    reserve: 'Reserve',
+    heightWarning: {
+      bridge: (height: string) =>
+        `The clearance height of the bridge leading to the harbor is ${height} m`,
+      bridges: (height: string) =>
+        `The clearance height of the bridges leading to the harbor is ${height} m`
+    }
   },
   citizen: {
     firstName: 'First Name',

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/fi.tsx
@@ -541,7 +541,13 @@ export default {
       Buck: 'Pukkisäilytys',
       BuckWithTent: 'Pukkisäilytys suojateltalla'
     },
-    reserve: 'Varaa'
+    reserve: 'Varaa',
+    heightWarning: {
+      bridge: (height: string) =>
+        `Satamaan johtavan sillan alituskorkeus on ${height} m`,
+      bridges: (height: string) =>
+        `Satamaan johtavien siltojen alituskorkeus ${height} m`
+    }
   },
   citizen: {
     firstName: 'Etunimi',

--- a/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
+++ b/frontend/src/lib-customizations/vekkuli/defaults/citizen/i18n/sv.tsx
@@ -540,7 +540,13 @@ const sv: Translations = {
       Buck: 'Förvaring på bock',
       BuckWithTent: 'Förvaring på bock med skyddstält'
     },
-    reserve: 'Boka'
+    reserve: 'Boka',
+    heightWarning: {
+      bridge: (height: string) =>
+        `Bron som leder till hamnen har en seglingshöjd på ${height} m`,
+      bridges: (height: string) =>
+        `Broarna som leder till hamnen har en seglingshöjd på ${height} m`
+    }
   },
   citizen: {
     firstName: 'Förnamn',

--- a/service/src/main/kotlin/fi/espoo/vekkuli/domain/BoatSpace.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/domain/BoatSpace.kt
@@ -15,6 +15,7 @@ data class BoatSpaceOption(
     val priceCents: Int,
     val locationName: String,
     val locationAddress: String,
+    val locationId: Int,
     val amenity: BoatSpaceAmenity,
     val formattedSizes: String =
         if (amenity != BoatSpaceAmenity.Buoy) "${formatInt(widthCm)} x ${formatInt(lengthCm)} m" else ""

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceRepository.kt
@@ -128,6 +128,7 @@ class JdbiBoatSpaceRepository(
                 SELECT 
                     location.name as location_name, 
                     location.address as location_address,
+                    location.id as location_id,
                     boat_space.id,
                     CONCAT(section, ' ', TO_CHAR(place_number, 'FM000')) as place,
                     length_cm, 
@@ -136,7 +137,7 @@ class JdbiBoatSpaceRepository(
                     amenity
                 FROM boat_space
                 JOIN location
-                ON location_id = location.id
+                ON boat_space.location_id = location.id
                 JOIN price
                 ON price_id = price.id
                 LEFT JOIN boat_space_reservation
@@ -170,7 +171,7 @@ class JdbiBoatSpaceRepository(
                         Harbor(
                             location =
                                 Location(
-                                    id = spaces.first().id,
+                                    id = spaces.first().locationId,
                                     name = locationName,
                                     address = spaces.first().locationAddress
                                 ),


### PR DESCRIPTION
Varoituselementti hakutuloksiin sillan alituskorkeudesta Laajalahteen ja Otsolahteen.

Käytetty kovakoodattuja location id -arvoja ko. paikkoihin. Api-responseen oli haettu boat_spacen id lokaation sijaan, vaihdettu palauttamaan location id:n varoitusta varten.
