### PR TITLE
TEST VP-1257: Bump fast-xml-parser from 4.5.0 to 5.0.6 in /api-gateway

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -21,7 +21,7 @@
     "express": "^5.0.1",
     "express-http-proxy": "^2.1.1",
     "express-session": "^1.18.0",
-    "fast-xml-parser": "^4.5.0",
+    "fast-xml-parser": "^5.0.6",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",

--- a/api-gateway/yarn.lock
+++ b/api-gateway/yarn.lock
@@ -1912,14 +1912,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "fast-xml-parser@npm:4.5.0"
+"fast-xml-parser@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "fast-xml-parser@npm:5.0.6"
   dependencies:
-    strnum: "npm:^1.0.5"
+    strnum: "npm:^2.0.4"
   bin:
     fxparser: src/cli/cli.js
-  checksum: dc9571c10e7b57b5be54bcd2d92f50c446eb42ea5df347d253e94dd14eb99b5300a6d172e840f151e0721933ca2406165a8d9b316a6d777bf0596dc4fe1df756
+  checksum: e1b8692e9723613fb74357921508b7abbd5ef0b9471f24479e9b34de4aaee7c4bd7b56696ded9351f3954803f04b0cb696175ae7d93ae44fd5c0f1ebb054ff2f
   languageName: node
   linkType: hard
 
@@ -3887,10 +3887,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "strnum@npm:1.0.5"
-  checksum: d3117975db8372d4d7b2c07601ed2f65bf21cc48d741f37a8617b76370d228f2ec26336e53791ebc3638264d23ca54e6c241f57f8c69bd4941c63c79440525ca
+"strnum@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "strnum@npm:2.0.4"
+  checksum: 5c23c6524cac6b6aa3752ffb21e5e86cdb7e1c91451a5db2f87c9677f92e9962d6f24c572d1d219b83658921b58047002d40050b9b8e1b36ba904fb86ee6ac5d
   languageName: node
   linkType: hard
 
@@ -4235,7 +4235,7 @@ __metadata:
     express: "npm:^5.0.1"
     express-http-proxy: "npm:^2.1.1"
     express-session: "npm:^1.18.0"
-    fast-xml-parser: "npm:^4.5.0"
+    fast-xml-parser: "npm:^5.0.6"
     helmet: "npm:^8.0.0"
     jsonwebtoken: "npm:^9.0.2"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
This is a duplicate of #850 to test the theory that it's only `dependabot` pull requests that are failing, not team member ones

Bumps [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser) from 4.5.0 to 5.0.6.
- [Release notes](https://github.com/NaturalIntelligence/fast-xml-parser/releases)
- [Changelog](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md)
- [Commits](https://github.com/NaturalIntelligence/fast-xml-parser/compare/v4.5.0...v5.0.6)

---
updated-dependencies:
- dependency-name: fast-xml-parser
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>