### PR TITLE
Optimize filtering unreserved spaces query

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiBoatSpaceRepository.kt
@@ -142,8 +142,8 @@ class JdbiBoatSpaceRepository(
                 ON boat_space.price_id = price.id
                 WHERE NOT EXISTS (
                     SELECT 1 
-                    FROM boat_space_reservation bsr
-                    WHERE bsr.boat_space_id = boat_space.id
+                    FROM boat_space_reservation 
+                    WHERE boat_space_reservation.boat_space_id = boat_space.id
                     AND (
                         (boat_space_reservation.created <= :currentTime) AND
                         (boat_space_reservation.status IN ('Info', 'Payment') AND boat_space_reservation.created > :currentTime - make_interval(secs => :sessionTimeInSeconds)) OR


### PR DESCRIPTION
Changed LEFT JOIN and WHERE IS NULL to NOT EXISTS.

Looking at the EXPLAIN ANALYZE for before and after this change this changes a 
Nested Loop to Hash Join, which should be faster. 

Tested locally with data from staging:

Before:

```
 Sort  (cost=318.12..318.12 rows=1 width=126) (actual time=8.909..8.996 rows=1546 loops=1)
   Sort Key: boat_space.width_cm, boat_space.length_cm, boat_space.section, boat_space.place_number
   Sort Method: quicksort  Memory: 216kB
   ->  Nested Loop  (cost=144.92..318.11 rows=1 width=126) (actual time=2.469..5.867 rows=1546 loops=1)
         ->  Nested Loop  (cost=144.77..317.92 rows=1 width=94) (actual time=2.455..4.078 rows=1546 loops=1)
               ->  Hash Right Join  (cost=144.62..317.74 rows=1 width=30) (actual time=2.441..2.765 rows=1546 loops=1)
                     Hash Cond: (boat_space_reservation.boat_space_id = boat_space.id)
                     Filter: (boat_space_reservation.id IS NULL)
                     Rows Removed by Filter: 2837
                     ->  Seq Scan on boat_space_reservation  (cost=0.00..165.66 rows=2837 width=8) (actual time=0.005..0.493 rows=2837 loops=1)
                           Filter: ((created <= now()) OR ((status = ANY ('{Info,Payment}'::reservationstatus[])) AND (created > (now() - '01:00:00'::interval))) OR ((status = ANY ('{Confirmed,Invoiced}'::reservationstatus[])) AND (end_date >= (now())::date)) OR ((status = 'Cancelled'::reservationstatus) AND (end_date > (now())::date)))
                     ->  Hash  (cost=89.83..89.83 rows=4383 width=30) (actual time=1.498..1.498 rows=4383 loops=1)
                           Buckets: 8192  Batches: 1  Memory Usage: 339kB
                           ->  Seq Scan on boat_space  (cost=0.00..89.83 rows=4383 width=30) (actual time=0.006..0.637 rows=4383 loops=1)
               ->  Index Scan using location_pkey on location  (cost=0.15..0.18 rows=1 width=68) (actual time=0.001..0.001 rows=1 loops=1546)
                     Index Cond: (id = boat_space.location_id)
         ->  Index Scan using price_pkey on price  (cost=0.15..0.18 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=1546)
               Index Cond: (id = boat_space.price_id)
 Planning Time: 0.516 ms
 Execution Time: 9.298 ms
```


After:

```
 Sort  (cost=482.09..485.95 rows=1546 width=126) (actual time=6.217..6.306 rows=1546 loops=1)
   Sort Key: boat_space.width_cm, boat_space.length_cm, boat_space.section, boat_space.place_number
   Sort Method: quicksort  Memory: 216kB
   ->  Hash Join  (cost=264.33..400.19 rows=1546 width=126) (actual time=0.942..3.080 rows=1546 loops=1)
         Hash Cond: (boat_space.price_id = price.id)
         ->  Hash Join  (cost=230.25..354.32 rows=1546 width=94) (actual time=0.907..2.351 rows=1546 loops=1)
               Hash Cond: (boat_space.location_id = location.id)
               ->  Hash Anti Join  (cost=201.13..321.11 rows=1546 width=30) (actual time=0.887..2.068 rows=1546 loops=1)
                     Hash Cond: (boat_space.id = bsr.boat_space_id)
                     ->  Seq Scan on boat_space  (cost=0.00..89.83 rows=4383 width=30) (actual time=0.003..0.614 rows=4383 loops=1)
                     ->  Hash  (cost=165.66..165.66 rows=2837 width=4) (actual time=0.863..0.864 rows=2837 loops=1)
                           Buckets: 4096  Batches: 1  Memory Usage: 132kB
                           ->  Seq Scan on boat_space_reservation bsr  (cost=0.00..165.66 rows=2837 width=4) (actual time=0.005..0.513 rows=2837 loops=1)
                                 Filter: ((created <= now()) OR ((status = ANY ('{Info,Payment}'::reservationstatus[])) AND (created > (now() - '01:00:00'::interval))) OR ((status = ANY ('{Confirmed,Invoiced}'::reservationstatus[])) AND (end_date >= (now())::date)) OR ((status = 'Cancelled'::reservationstatus) AND (end_date > (now())::date)))
               ->  Hash  (cost=18.50..18.50 rows=850 width=68) (actual time=0.010..0.010 rows=8 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 9kB
                     ->  Seq Scan on location  (cost=0.00..18.50 rows=850 width=68) (actual time=0.004..0.005 rows=8 loops=1)
         ->  Hash  (cost=20.70..20.70 rows=1070 width=8) (actual time=0.021..0.022 rows=24 loops=1)
               Buckets: 2048  Batches: 1  Memory Usage: 17kB
               ->  Seq Scan on price  (cost=0.00..20.70 rows=1070 width=8) (actual time=0.006..0.009 rows=24 loops=1)
 Planning Time: 0.444 ms
 Execution Time: 6.597 ms
```

