### PR TITLE
Redirect failed saml logins to citizen frontpage

### DIFF
--- a/api-gateway/src/auth/saml/saml-routes.ts
+++ b/api-gateway/src/auth/saml/saml-routes.ts
@@ -34,7 +34,7 @@ export interface SamlEndpointConfig {
   strategy: passportSaml.Strategy
 }
 
-const defaultNoAuthUrl = '/kirjaudu?loginError=true'
+const defaultNoAuthUrl = '/'
 
 function createLoginHandler({
   sessions,


### PR DESCRIPTION
This change redirects all failed SAML logins to the citizen front page. It might or might not also affect employees, as I couldn't find a cancel or back button in the AD login flow. However, let's prioritize citizens for now.