### PR TITLE
Revert "Bump dd-trace from 5.40.0 to 5.41.1 in /api-gateway"

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -19,7 +19,7 @@
     "cookie-parser": "^1.4.6",
     "csurf": "^1.11.0",
     "date-fns": "^4.1.0",
-    "dd-trace": "^5.41.1",
+    "dd-trace": "^5.40.0",
     "express": "^5.0.1",
     "express-http-proxy": "^2.1.1",
     "express-session": "^1.18.0",

--- a/api-gateway/yarn.lock
+++ b/api-gateway/yarn.lock
@@ -21,10 +21,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/libdatadog@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@datadog/libdatadog@npm:0.5.0"
-  checksum: 94069076c9921d8fbbce103482f0215c5c361ab0efb6c87c77063ac259e1bc3d2be3a4b87fde3167e9d449c944a9009eca9d9063d8f3ecbac1f599a3a085d989
+"@datadog/libdatadog@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@datadog/libdatadog@npm:0.4.0"
+  checksum: f56b58fdc24e136a47cde999726d6cbf2478cb9bbe0179b2c8b82b4d97f7b036e732c80a1191ad2241913e92a097adc554bcb75024ff73b0e493f0adee1495d3
   languageName: node
   linkType: hard
 
@@ -999,7 +999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.14.0":
+"acorn@npm:^8.14.0, acorn@npm:^8.8.2":
   version: 8.14.0
   resolution: "acorn@npm:8.14.0"
   bin:
@@ -1551,11 +1551,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dd-trace@npm:^5.41.1":
-  version: 5.41.1
-  resolution: "dd-trace@npm:5.41.1"
+"dd-trace@npm:^5.40.0":
+  version: 5.40.0
+  resolution: "dd-trace@npm:5.40.0"
   dependencies:
-    "@datadog/libdatadog": "npm:^0.5.0"
+    "@datadog/libdatadog": "npm:^0.4.0"
     "@datadog/native-appsec": "npm:8.4.0"
     "@datadog/native-iast-rewriter": "npm:2.8.0"
     "@datadog/native-iast-taint-tracking": "npm:3.3.0"
@@ -1568,7 +1568,7 @@ __metadata:
     crypto-randomuuid: "npm:^1.0.0"
     dc-polyfill: "npm:^0.1.4"
     ignore: "npm:^5.2.4"
-    import-in-the-middle: "npm:1.13.1"
+    import-in-the-middle: "npm:1.11.2"
     istanbul-lib-coverage: "npm:3.2.0"
     jest-docblock: "npm:^29.7.0"
     koalas: "npm:^1.0.2"
@@ -1587,7 +1587,7 @@ __metadata:
     source-map: "npm:^0.7.4"
     tlhunter-sorted-set: "npm:^0.1.0"
     ttl-set: "npm:^1.0.0"
-  checksum: 214a6879e61ed6364534bc138efbf086983bccd1dbe77ccd43b8060b3cd79de4771a7b663169a6f5758b80c8ed69c9219adc61a2c0b0831650fdd747f66c119b
+  checksum: 1e1ca3ae7c034efd8e480710bd6d31ed57ff3b14e3eb1b44d045f2fa8f7e15ba6726f664120cacf64b80533fe0605b38493224b1fffa58e785e394fb67d353ab
   languageName: node
   linkType: hard
 
@@ -2655,15 +2655,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-in-the-middle@npm:1.13.1":
-  version: 1.13.1
-  resolution: "import-in-the-middle@npm:1.13.1"
+"import-in-the-middle@npm:1.11.2":
+  version: 1.11.2
+  resolution: "import-in-the-middle@npm:1.11.2"
   dependencies:
-    acorn: "npm:^8.14.0"
+    acorn: "npm:^8.8.2"
     acorn-import-attributes: "npm:^1.9.5"
     cjs-module-lexer: "npm:^1.2.2"
     module-details-from-path: "npm:^1.0.3"
-  checksum: fea083fb2d6a9607702e3f4d675b19c52f3ebc271c9050f2a041966910bfd04047b100b13112f10109415c87c312206a8591d4a883fdedeb1f27e6637a96c852
+  checksum: ebd1aaba4441e54db124670e13038127f5283b686d83276dc004cd9d3bb1747e63ac37935c3c58885b52aedf48e669093d24ffe4b5849adef744d79ee67445ad
   languageName: node
   linkType: hard
 
@@ -4695,7 +4695,7 @@ __metadata:
     cookie-parser: "npm:^1.4.6"
     csurf: "npm:^1.11.0"
     date-fns: "npm:^4.1.0"
-    dd-trace: "npm:^5.41.1"
+    dd-trace: "npm:^5.40.0"
     eslint: "npm:9.22.0"
     eslint-config-prettier: "npm:^10.1.1"
     eslint-plugin-prettier: "npm:^5.2.1"


### PR DESCRIPTION
This reverts commit d19d649da8ecdc6bf51a986b13dc5bf9dae11015.