### PR TITLE
Filter empty emails out.

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/controllers/MessageSendingController.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/controllers/MessageSendingController.kt
@@ -119,6 +119,6 @@ class MessageSendingController(
                 contactDetails.addAll(orgRecipients)
                 contactDetails
             }
-        return recipients.flatten().distinctBy { it.id }
+        return recipients.flatten().distinctBy { it.id }.filter { it.email.isNotEmpty() }
     }
 }


### PR DESCRIPTION
When sending (mass) emails, filter out recipients with empty emails.