### PR TITLE
Prevent missing auth routes from redirecting citizens to employee section

### DIFF
--- a/api-gateway/src/auth/dev-ad-auth.ts
+++ b/api-gateway/src/auth/dev-ad-auth.ts
@@ -136,5 +136,9 @@ export function createDevAdRouter(sessions: Sessions): Router {
     })
   )
 
+  router.use('/*splat', (_req, res) => {
+    res.redirect(employeeRootUrl)
+  })
+
   return router
 }

--- a/api-gateway/src/auth/dev-sfi-auth.ts
+++ b/api-gateway/src/auth/dev-sfi-auth.ts
@@ -192,5 +192,9 @@ export function createDevSfiRouter(sessions: Sessions): Router {
     })
   )
 
+  router.use('/*splat', (_req, res) => {
+    res.redirect(citizenRootUrl)
+  })
+
   return router
 }

--- a/api-gateway/src/auth/saml/saml-routes.ts
+++ b/api-gateway/src/auth/saml/saml-routes.ts
@@ -25,10 +25,11 @@ const urlencodedParser = urlencoded({ extended: false })
 type Role = 'employee' | 'citizen'
 
 export function getRedirectUrl(type: Role, req: express.Request): string {
-  return (
-    parseRelayState(req) ??
-    (type === 'employee' ? employeeRootUrl : citizenRootUrl)
-  )
+  return parseRelayState(req) ?? getRootUrl(type)
+}
+
+export function getRootUrl(type: Role): string {
+  return type === 'employee' ? employeeRootUrl : citizenRootUrl
 }
 
 export interface SamlEndpointConfig {
@@ -197,6 +198,10 @@ export default function createSamlRouter(
     (req, res) => res.redirect(getRedirectUrl(endpointConfig.type, req))
   )
   router.use('/logout', logoutErrorHandler)
+
+  router.use('/*splat', (_req, res) => {
+    res.redirect(getRootUrl(endpointConfig.type))
+  })
 
   return router
 }

--- a/api-gateway/src/authRouter.ts
+++ b/api-gateway/src/authRouter.ts
@@ -10,7 +10,7 @@ import createSamlRouter from './auth/saml/saml-routes.js'
 import { sessionSupport } from './auth/session.js'
 import { createSuomiFiStrategy } from './auth/suomifi-saml.js'
 import { RedisClient } from './clients/redis-client.js'
-import { Config } from './config.js'
+import { citizenRootUrl, Config } from './config.js'
 import { cacheControl } from './middleware/cache-control.js'
 import { errorHandler } from './middleware/errors.js'
 
@@ -86,6 +86,10 @@ export function createAuthRouter(
       })
     )
   }
+
+  router.use('/*splat', (_req, res) => {
+    res.redirect(citizenRootUrl)
+  })
 
   router.use(errorHandler)
 


### PR DESCRIPTION
A failed login attempt might redirect the citizen to `/auth/saml-suomifi/`, which is not a valid endpoint in the auth router. This request is eventually redirected to `/virkailija` by the `employeeRouter`, which may lead citizens to mistakenly attempt logging in with AD

Added catch-all routes in the Suomi.fi and AD routers to redirect users to the appropriate sections.
