### PR TITLE
Remove the single hyphen from text input when editing value.

### DIFF
--- a/frontend/src/citizen-frontend/components/boat-list/formDefinitions.ts
+++ b/frontend/src/citizen-frontend/components/boat-list/formDefinitions.ts
@@ -47,7 +47,7 @@ export const boatForm = mapped(
 export type BoatForm = typeof boatForm
 
 export const transformBoatToFormBoat = (boat: Boat): StateOf<BoatForm> => ({
-  name: boat.name || '-',
+  name: boat.name || '',
   depth: boat.depth.toString(),
   length: boat.length.toString(),
   weight: boat.weight.toString(),
@@ -60,9 +60,9 @@ export const transformBoatToFormBoat = (boat: Boat): StateOf<BoatForm> => ({
       value: type
     }))
   },
-  registrationNumber: boat.registrationNumber || '-',
-  extraInformation: boat.extraInformation || '-',
-  otherIdentification: boat.otherIdentification || '-',
+  registrationNumber: boat.registrationNumber || '',
+  extraInformation: boat.extraInformation || '',
+  otherIdentification: boat.otherIdentification || '',
   ownership: {
     domValue: boat.ownership,
     options: ownershipStatuses.map((type) => ({

--- a/frontend/src/lib-components/form/TextField.tsx
+++ b/frontend/src/lib-components/form/TextField.tsx
@@ -43,7 +43,7 @@ export default React.memo(function TextField({
           {required && ' *'}
         </label>
         {readonly ? (
-          <ReadOnly dataTestId={dataTestId} value={readOnlyValue} />
+          <ReadOnly dataTestId={dataTestId} value={readOnlyValue || '-'} />
         ) : (
           <>
             <input
@@ -51,7 +51,7 @@ export default React.memo(function TextField({
               type="text"
               id={id}
               name={name}
-              value={state === '-' ? '' : state}
+              value={state}
               aria-label={ariaLabel}
               aria-required={required}
               aria-invalid={showError}


### PR DESCRIPTION
Input with no value in readonly in citizen profile page:

<img width="170" alt="image" src="https://github.com/user-attachments/assets/493cb2bf-3f62-49df-a735-2efa54c04039" />


Editing, before:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/01a60db4-b95f-4f62-b7f1-edda45a3af18" />


Editing, after:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/03699775-7094-41af-a23b-a8ea4d8d7dd2" />

