### PR TITLE
Move Paytrail cache from Redis to Postgres

### DIFF
--- a/compose/docker-compose.e2e-test.yml
+++ b/compose/docker-compose.e2e-test.yml
@@ -48,8 +48,6 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://vekkuli-db:5432/vekkuli
       SPRING_DATASOURCE_USERNAME: vekkuli
       SPRING_DATASOURCE_PASSWORD: postgres
-      SPRING_DATA_REDIS_HOST: redis
-      SPRING_DATA_REDIS_PORT: 6379
       ENVIRONMENT: local-docker
     entrypoint: ./e2e-test-entrypoint.sh
     depends_on:

--- a/compose/docker-compose.e2e.yml
+++ b/compose/docker-compose.e2e.yml
@@ -25,8 +25,6 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://vekkuli-db:5432/vekkuli
       SPRING_DATASOURCE_USERNAME: vekkuli
       SPRING_DATASOURCE_PASSWORD: postgres
-      SPRING_DATA_REDIS_HOST: redis
-      SPRING_DATA_REDIS_PORT: 6379
       APP_JWT_PUBLIC_KEYS_URL: classpath:local-development/jwks.json
 
   api-gateway:

--- a/compose/docker-compose.integration.yml
+++ b/compose/docker-compose.integration.yml
@@ -26,9 +26,6 @@ services:
     environment:
       JAVA_OPTS: -server -Djava.security.egd=file:/dev/./urandom -Xms1024m -Xss512k -Xmx1024m -XX:TieredStopAtLevel=1
       SPRING_DATASOURCE_URL: jdbc:postgresql://vekkuli-db:5432/vekkuli
-      SPRING_DATA_REDIS_HOST: redis
-      SPRING_DATA_REDIS_PORT: 6379
     entrypoint: ./gradlew integrationTest
     depends_on:
       - vekkuli-db
-      - redis

--- a/compose/docker-compose.test-service.yml
+++ b/compose/docker-compose.test-service.yml
@@ -11,9 +11,6 @@ services:
     environment:
       JAVA_OPTS: -server -Djava.security.egd=file:/dev/./urandom -Xms1024m -Xss512k -Xmx1024m -XX:TieredStopAtLevel=1
       SPRING_DATASOURCE_URL: jdbc:postgresql://vekkuli-db:5432/vekkuli
-      SPRING_DATA_REDIS_HOST: redis
-      SPRING_DATA_REDIS_PORT: 6379
     entrypoint: ./gradlew test
     depends_on:
       - vekkuli-db
-      - redis

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -138,8 +138,6 @@ dependencies {
     implementation("ch.qos.logback:logback-core:1.5.16")
     implementation("commons-codec:commons-codec:1.18.0")
 
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
-
     downloadOnly("com.datadoghq:dd-java-agent:1.48.1")
 }
 

--- a/service/src/main/resources/db/migration/V018__paytrail_payment_cache.sql
+++ b/service/src/main/resources/db/migration/V018__paytrail_payment_cache.sql
@@ -1,0 +1,8 @@
+CREATE TABLE paytrail_payment_cache (
+    transaction_id TEXT PRIMARY KEY,
+    response JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_paytrail_payment_cache_expires_at ON paytrail_payment_cache (expires_at);


### PR DESCRIPTION
Moves Paytrail response cache from Redis to Postgres. Cache items are cleared nightly after 7 days.

**NOTE: Since this does not migrate cache data from Redis, this must be deployed while there are no ongoing payments.**