### PR TITLE
Check also empty codes, not just nulls.

### DIFF
--- a/service/src/main/kotlin/fi/espoo/vekkuli/service/BoatReservationService.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/service/BoatReservationService.kt
@@ -330,7 +330,7 @@ class BoatReservationService(
             warnings.add(Pair(ReservationWarningType.BoatType, null))
         }
 
-        if (boat.registrationCode != null) {
+        if (!boat.registrationCode.isNullOrBlank()) {
             val boatsWithSameRegistrationCode: List<Pair<Boat, ReserverWithDetails?>> =
                 getBoatAndReserverWithRegistrationCode(boat.registrationCode)
                     .filter { it.first.id != boat.id }


### PR DESCRIPTION
Prevent a bunch of emails and boats  be listed as having same registation code when the code is empty. 