### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   cleanup:
+    permissions:
+      packages: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/espoon-voltti/vekkuli/security/code-scanning/1](https://github.com/espoon-voltti/vekkuli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses the `actions/delete-package-versions@v5` action to delete package versions, it requires `packages: write` permission. We will explicitly set this permission for the job while limiting all other permissions to `read` or `none`. This ensures the workflow has only the permissions it needs to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
