### PR TITLE
Small UI fixes

### DIFF
--- a/frontend/src/citizen-frontend/components/trailer/TrailerInformation.tsx
+++ b/frontend/src/citizen-frontend/components/trailer/TrailerInformation.tsx
@@ -142,6 +142,7 @@ function TrailerForm({
             label={i18n.reservation.formPage.trailerInfo.registrationNumber}
             bind={registrationNumber}
             readonly={!editMode}
+            required={true}
           />
         </Column>
         <Column isOneQuarter>
@@ -150,6 +151,7 @@ function TrailerForm({
             bind={width}
             readonly={!editMode}
             precision={2}
+            required={true}
           />
         </Column>
         <Column isOneQuarter>
@@ -158,6 +160,7 @@ function TrailerForm({
             bind={length}
             readonly={!editMode}
             precision={2}
+            required={true}
           />
         </Column>
       </Columns>

--- a/frontend/src/citizen-frontend/main.scss
+++ b/frontend/src/citizen-frontend/main.scss
@@ -422,14 +422,29 @@ body > .columns {
   }
 }
 
+.reservation-price-info {
+  align-items: center;
+}
 
-.reservation-info, .reservation-price-info {
+.message-box {
   padding: $spacing-medium;
   border: 1px solid $bulma-primary;
   border-radius: 4px;
   display: flex;
   margin-bottom: $spacing-large;
+  align-items: center;
 
+  &.is-info {
+    border-color: $bulma-primary;
+  }
+
+  &.is-warning {
+    border-color: $warning;
+  }
+
+  &.is-error {
+    border-color: $warning;
+  }
 
   .info-icon {
     flex: 1;
@@ -443,29 +458,9 @@ body > .columns {
   p.column span {
     display: block;
   }
-}
 
-.reservation-price-info {
-  align-items: center;
-}
-
-.message-box {
-  padding: $spacing-medium;
-  border: 1px solid $bulma-primary;
-  border-radius: 4px;
-  display: flex;
-  margin-bottom: $spacing-large;
-
-  &.is-info {
-    border-color: $bulma-primary;
-  }
-
-  &.is-warning {
-    border-color: $warning;
-  }
-
-  &.is-error {
-    border-color: $warning;
+  .column.is-narrow {
+    flex: none;
   }
 }
 

--- a/frontend/src/citizen-frontend/main.scss
+++ b/frontend/src/citizen-frontend/main.scss
@@ -561,6 +561,10 @@ body > .columns {
   }
 }
 
+.dropdown {
+  display: flex;
+}
+
 .dropdown-content {
   border: 1px solid #A9B0BB;
   border-top: 0;
@@ -596,6 +600,10 @@ body > .columns {
 }
 .nav-row > .columns {
   margin: 0;
+}
+
+.nav-row .column {
+  flex-basis: auto;
 }
 
 .link.active {

--- a/frontend/src/citizen-frontend/reservation/components/ReserverPriceInfo.tsx
+++ b/frontend/src/citizen-frontend/reservation/components/ReserverPriceInfo.tsx
@@ -47,7 +47,7 @@ export default React.memo(function ReserverPriceInfo({
   return switchText || discountText ? (
     <div
       id="empty-dimensions-warning"
-      className="reservation-info column is-four-fifths"
+      className="message-box column is-four-fifths"
     >
       <div className="column is-narrow">
         <span className="icon">

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/Boat.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/Boat.tsx
@@ -1,3 +1,4 @@
+import { FormSection } from 'lib-components/form'
 import React from 'react'
 
 import { useTranslation } from 'citizen-frontend/localization'
@@ -23,7 +24,7 @@ export default React.memo(function Boat({
   const { boatInfo, boatSelection, ownership } = useFormFields(bind)
 
   return (
-    <div data-testid="boat">
+    <FormSection data-testid="boat">
       <div className="form-section no-bottom-border">
         <h3 className="header">{i18n.reservation.formPage.boatInformation}</h3>
         <ExistingBoat bind={boatSelection} />
@@ -34,6 +35,6 @@ export default React.memo(function Boat({
         />
       </div>
       <BoatOwnershipStatus bind={ownership} />
-    </div>
+    </FormSection>
   )
 })

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/Boat.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/Boat.tsx
@@ -24,7 +24,7 @@ export default React.memo(function Boat({
 
   return (
     <div data-testid="boat">
-      <div className="form-section">
+      <div className="form-section no-bottom-border">
         <h3 className="header">{i18n.reservation.formPage.boatInformation}</h3>
         <ExistingBoat bind={boatSelection} />
         <BoatInfo

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/BoatInfo.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/boat/BoatInfo.tsx
@@ -1,3 +1,5 @@
+import { Column } from 'lib-components/dom'
+import Columns from 'lib-components/dom/Columns'
 import { CheckboxField } from 'lib-components/form/CheckboxField'
 import { NumberField } from 'lib-components/form/NumberField'
 import { SelectField } from 'lib-components/form/SelectField'
@@ -58,15 +60,15 @@ export default React.memo(function Boat({
   return (
     <>
       <div className="columns">
-        <div className="column is-one-quarter">
+        <Column isOneQuarter>
           <TextField
             id="boatName"
             label={i18n.boat.boatName}
             bind={name}
             required={true}
           />
-        </div>
-        <div className="column is-one-quarter">
+        </Column>
+        <Column isOneQuarter>
           <SelectField
             id="boat-type"
             name="boatType"
@@ -74,8 +76,8 @@ export default React.memo(function Boat({
             required={true}
             bind={type}
           />
-        </div>
-        <div className="column is-one-quarter">
+        </Column>
+        <Column isOneQuarter>
           <NumberField
             id="boat-width"
             label={i18n.common.unit.dimensions.widthInMeters}
@@ -87,8 +89,8 @@ export default React.memo(function Boat({
             required={true}
             precision={2}
           />
-        </div>
-        <div className="column is-one-quarter">
+        </Column>
+        <Column isOneQuarter>
           <NumberField
             id="boat-height"
             label={i18n.common.unit.dimensions.lengthInMeters}
@@ -100,11 +102,11 @@ export default React.memo(function Boat({
             required={true}
             precision={2}
           />
-        </div>
+        </Column>
       </div>
       {showSizeWarning && <BoatSizeWarning reservationId={reservationId} />}
-      <div className="columns is-vcentered">
-        <div className="column is-one-quarter">
+      <Columns isVCentered>
+        <Column isOneQuarter>
           <NumberField
             id="boat-depth"
             label={i18n.boat.boatDepthInMeters}
@@ -116,8 +118,8 @@ export default React.memo(function Boat({
             required={true}
             precision={2}
           />
-        </div>
-        <div className="column is-one-quarter">
+        </Column>
+        <Column isOneQuarter>
           <NumberField
             id="boat-weight"
             label={i18n.boat.boatWeightInKg}
@@ -128,46 +130,46 @@ export default React.memo(function Boat({
             max={9999999}
             required={true}
           />
-        </div>
-      </div>
-      {showWeightWarning && <BoatWeightWarning reservationId={reservationId} />}
-      <div className="columns is-vcentered">
+        </Column>
+        {showWeightWarning && (
+          <BoatWeightWarning reservationId={reservationId} />
+        )}
         {noRegisterNumber.state.domValues.length === 0 && (
-          <div className="column is-one-quarter">
+          <Column isOneQuarter>
             <TextField
               id="register-number"
               label={i18n.boat.registrationNumber}
               bind={registrationNumberValue}
               required={true}
             />
-          </div>
+          </Column>
         )}
-        <div className="column is-one-quarter">
+        <Column isOneQuarter>
           <CheckboxField
             id="no-register-number"
             name="noRegisterNumber"
             bind={noRegisterNumber}
             isFullWidth={true}
           />
-        </div>
-      </div>
-      <div className="columns is-vcentered">
-        <div className="column is-one-quarter">
+        </Column>
+      </Columns>
+      <Columns isVCentered>
+        <Column isOneQuarter>
           <TextField
             id="other-identifier"
             label={i18n.boat.otherIdentifier}
             bind={otherIdentification}
             required={true}
           />
-        </div>
-        <div className="column is-one-quarter">
+        </Column>
+        <Column isOneQuarter>
           <TextField
             id="additional-info"
             label={i18n.boat.additionalInfo}
             bind={extraInformation}
           />
-        </div>
-      </div>
+        </Column>
+      </Columns>
     </>
   )
 })
@@ -176,7 +178,7 @@ const BoatSizeWarning = ({ reservationId }: { reservationId: number }) => {
   const i18n = useTranslation()
 
   return (
-    <div className="columns is-vcentered">
+    <Columns isVCentered>
       <div className="warning" id="boatSize-warning">
         <p className="block">{i18n.boat.boatSizeWarning}</p>
         <p className="block">{i18n.boat.boatSizeWarningExplanation}</p>
@@ -184,14 +186,14 @@ const BoatSizeWarning = ({ reservationId }: { reservationId: number }) => {
           {i18n.reservation.goBack}
         </ReservationCancel>
       </div>
-    </div>
+    </Columns>
   )
 }
 
 const BoatWeightWarning = ({ reservationId }: { reservationId: number }) => {
   const i18n = useTranslation()
   return (
-    <div className="columns is-vcentered">
+    <Columns isVCentered>
       <div className="warning" id="boatWeight-warning">
         <p className="block">{i18n.boat.boatWeightWarning}</p>
         <p className="block">{i18n.boat.boatWeightWarning2}</p>
@@ -199,6 +201,6 @@ const BoatWeightWarning = ({ reservationId }: { reservationId: number }) => {
           {i18n.reservation.goBack}
         </ReservationCancel>
       </div>
-    </div>
+    </Columns>
   )
 }

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/winterStorageType/StorageType.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/winterStorageType/StorageType.tsx
@@ -16,7 +16,7 @@ export default React.memo(function StorageType({
   const i18n = useTranslation()
   const storageType = bind.state.domValue
   return (
-    <Column isFull>
+    <>
       <RadioField
         id="winter-storage-type"
         name="winterStorageType"
@@ -29,6 +29,6 @@ export default React.memo(function StorageType({
           text={i18n.reservation.formPage.storageInfo.buckWithTentInfo}
         />
       )}
-    </Column>
+    </>
   )
 })

--- a/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/winterStorageType/WinterStorageType.tsx
+++ b/frontend/src/citizen-frontend/reservation/pages/fillInformation/sections/winterStorageType/WinterStorageType.tsx
@@ -1,4 +1,3 @@
-import { Column, Columns } from 'lib-components/dom'
 import { FormSection } from 'lib-components/form'
 import React from 'react'
 
@@ -21,12 +20,8 @@ export default React.memo(function WinterStorageType({
   return (
     <FormSection data-testid="winter-storage-type">
       <h3 className="header">{i18n.reservation.formPage.storageType}</h3>
-      <Columns>
-        <Column>
-          <StorageType bind={storageType} />
-          {branch === 'Trailer' && <TrailerInfo bind={form} />}
-        </Column>
-      </Columns>
+      <StorageType bind={storageType} />
+      {branch === 'Trailer' && <TrailerInfo bind={form} />}
     </FormSection>
   )
 })

--- a/frontend/src/lib-components/form/NumberField.tsx
+++ b/frontend/src/lib-components/form/NumberField.tsx
@@ -45,7 +45,7 @@ function NumberFieldR({
       <div className="control">
         <label className="label" htmlFor={id}>
           {label}
-          {required && ' *'}
+          {required && !readonly && ' *'}
         </label>
         {readonly ? (
           <ReadOnly value={formatNumber(readOnlyValue, precision) || '-'} />

--- a/frontend/src/lib-components/form/SelectField.tsx
+++ b/frontend/src/lib-components/form/SelectField.tsx
@@ -43,7 +43,7 @@ function SelectField_<T>({
       <div className="control">
         <label className="label" htmlFor={id}>
           {label}
-          {required && ' *'}
+          {required && !readonly && ' *'}
         </label>
         {readonly ? (
           <ReadOnly value={getI18nLabel(readOnlyValue, i18n)} />

--- a/frontend/src/lib-components/form/TextField.tsx
+++ b/frontend/src/lib-components/form/TextField.tsx
@@ -1,3 +1,4 @@
+import { EditLink } from 'lib-components/links'
 import React, { useState } from 'react'
 
 import { BoundFormState } from 'lib-common/form/hooks'
@@ -8,7 +9,6 @@ import { BaseFieldProps } from './BaseField'
 import FieldErrorContainer from './FieldErrorContainer'
 import ReadOnly from './ReadOnly'
 import { bindOrPlaceholders } from './utils'
-import { EditLink } from 'lib-components/links'
 
 interface TextFieldProps extends Omit<BaseFieldProps, 'onChange' | 'value'> {
   bind?: BoundFormState<string>
@@ -48,7 +48,7 @@ export default React.memo(function TextField({
             htmlFor={id}
           >
             {label}
-            {required && ' *'}
+            {required && !readonly && ' *'}
           </label>
           {editAction && (
             <EditLink action={editAction} dataTestId={`edit-${dataTestId}`} />


### PR DESCRIPTION
## fix navigation bar not lining up
Before:
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/6d3af2b3-6e8a-4b39-a2c7-bce95fcf5e10" />

After:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/35357e69-6edc-4da2-b24e-fbdb914bb550" />

## remove bottom border from between boat info input and boat ownership
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/4f908070-5f8e-4a83-9930-02d22466823a" />


## info box should look the same on mobile
Before:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/46c90125-4b2b-4a8e-a7cb-8257423b204b" />

After:
<img width="608" alt="image" src="https://github.com/user-attachments/assets/c9a465b0-868e-4dbc-a402-1872544c3f4f" />
## asterisk for required inputs should only be shown for inputs
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/6ccc2767-46dc-4a81-8da3-4ea761498876" />
<img width="511" alt="image" src="https://github.com/user-attachments/assets/e07218b6-2aaa-4961-9a16-ed181de065e8" />

## there should be a section line between trailer info and boat info
<img width="843" alt="image" src="https://github.com/user-attachments/assets/e1bd94a0-0f2a-4dc3-8987-471acab37f49" />

## fix winter storage type field on the application

Before:
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/89365e0c-e12e-4efd-a388-856f45c0b2a6" />


After:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/96263203-72c7-4697-a1e6-31e961533db7" />
