### PR TITLE
Migrate OSS Index to Sonatype Guide API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,11 +176,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load OWASP cache
-        uses: espoon-voltti/voltti-actions/owasp-cache-get@feature/owasp-cache-get
+        uses: espoon-voltti/voltti-actions/owasp-cache-get@master
         with:
           gh_token: ${{ secrets.VOLTTI_OWASP_TOKEN }}
           t_cache_base: "./"
           t_cache_dir: "dependency-check-data"
+          fail_on_miss: "true"
 
       - name: Run service OWASP tests
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,13 +175,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache dependency check database
-        uses: actions/cache@v5
+      - name: Load OWASP cache
+        uses: espoon-voltti/voltti-actions/owasp-cache-get@feature/owasp-cache-get
         with:
-          path: dependency-check-data
-          key: dependency-check-data-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            dependency-check-data-
+          gh_token: ${{ secrets.VOLTTI_OWASP_TOKEN }}
+          t_cache_base: "./"
+          t_cache_dir: "dependency-check-data"
 
       - name: Run service OWASP tests
         shell: bash
@@ -191,14 +190,7 @@ jobs:
               -e OSS_INDEX_USERNAME=${{ secrets.OSS_INDEX_USERNAME }} -e OSS_INDEX_PASSWORD=${{ secrets.OSS_INDEX_PASSWORD }} \
               -v $(pwd)/dependency-check-data:/root/.gradle/dependency-check-data \
               "${{ needs.service.outputs.builder_image }}" \
-              sh -c "./gradlew --no-daemon dependencyCheckUpdate && ./gradlew --no-daemon dependencyCheckAnalyze"
-
-      - name: Force caching dependency-check-data # If job fails cache is not saved without this
-        uses: actions/cache/save@v5
-        if: failure()
-        with:
-          path: dependency-check-data
-          key: dependency-check-data-${{ github.run_id }}-${{ github.run_attempt }}
+              sh -c "./gradlew --no-daemon dependencyCheckAnalyze"
 
   test:
     runs-on: ubuntu-latest

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -273,6 +273,7 @@ tasks {
             ossIndex.apply {
                 username = System.getenv("OSS_INDEX_USERNAME")
                 password = System.getenv("OSS_INDEX_PASSWORD")
+                url = "https://api.guide.sonatype.com"
             }
         }
         nvd.apply { apiKey = System.getenv("NVD_API_KEY") }


### PR DESCRIPTION
Update ossIndex URL to https://api.guide.sonatype.com for the OWASP dependency-check plugin as required by the OSS Index migration to Sonatype Guide (deadline: April 28, 2026).