### PR TITLE
Bump kotlinx-coroutines to 1.11.0 to match Ktor 3.5.0

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -129,8 +129,8 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:3.5.0") // Content negotiation
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.5.0") // kotlinx serialization
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-0.6.x-compat")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.11.0")
     implementation("org.reactivestreams:reactive-streams:1.0.4")
 
     // AWS dependencies

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -49,6 +49,12 @@ repositories {
     mavenCentral()
 }
 
+// Override Spring Boot's managed kotlinx-coroutines version. Ktor 3.5.0 requires
+// >=1.11.0; this keeps the WHOLE coroutines family (bom/core/reactor/reactive/slf4j)
+// aligned via Spring's dependency management, which otherwise force-pins it back to
+// 1.10.2 and breaks the suspend->Mono bridge (NoSuchMethodError in MonoCoroutine).
+extra["kotlin-coroutines.version"] = "1.11.0"
+
 sourceSets {
     register("e2eTest") {
         compileClasspath += main.get().output + test.get().output
@@ -129,8 +135,9 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:3.5.0") // Content negotiation
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.5.0") // kotlinx serialization
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-0.6.x-compat")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.11.0")
+    // Version managed by Spring Boot via the kotlin-coroutines.version override above.
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation("org.reactivestreams:reactive-streams:1.0.4")
 
     // AWS dependencies


### PR DESCRIPTION
Ktor 3.5.0 (#2337) is compiled against kotlinx-coroutines 1.11.0 and requests kotlinx-coroutines-slf4j:1.11.0 transitively. Its HttpClientEngine.createCallContext calls the 1.11.0 signature of Job.invokeOnCompletion(onCancelling, invokeImmediately, handler).

The explicit kotlinx-coroutines-core/-reactor:1.10.2 pins dragged in kotlinx-coroutines-bom:1.10.2, which constrained the whole family back down to 1.10.2, overriding Ktor's transitive 1.11.0 request. Since the offending call lives inside the prebuilt ktor-client-core jar, the build succeeded but staging threw at runtime:

  java.lang.NoSuchMethodError: kotlinx.coroutines.Job.invokeOnCompletion$default(...)
    at io.ktor.client.engine.HttpClientEngineKt.createCallContext(HttpClientEngine.kt:242)

Aligning the pins to 1.11.0 resolves the runtime classpath consistently (verified via dependencyInsight on runtimeClasspath).