### PR TITLE
Fix 500 when employee searches customers with whitespace-only term

### DIFF
--- a/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReserverServiceIntegrationTests.kt
+++ b/service/src/integrationTest/kotlin/fi/espoo/vekkuli/ReserverServiceIntegrationTests.kt
@@ -34,6 +34,14 @@ class ReserverServiceIntegrationTests : IntegrationTestBase() {
     }
 
     @Test
+    fun `should not throw when searching citizens with whitespace-only term`() {
+        // A whitespace-only search term must not cause a 500 (UnableToCreateStatementException).
+        // It should behave like an empty search.
+        val citizens = reserverService.getCitizens(" ")
+        assertNotNull(citizens, "Whitespace-only search should return a result list, not throw")
+    }
+
+    @Test
     fun `should get citizen by last name`() {
         val citizens = reserverService.getCitizens("Virtanen")
         assertEquals(2, citizens.size, "Should find two citizens")

--- a/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiReserverRepository.kt
+++ b/service/src/main/kotlin/fi/espoo/vekkuli/repository/JdbiReserverRepository.kt
@@ -105,7 +105,7 @@ class JdbiReserverRepository(
                     WHERE $nameSearchClause
                     """.trimIndent()
                 )
-            if (!nameSearch.isNullOrEmpty()) {
+            if (!nameSearch.isNullOrBlank()) {
                 query.bind("nameSearch", nameSearch.trim())
             }
             query.mapTo<CitizenWithDetails>().toList()


### PR DESCRIPTION
Employee reservation UIs search citizen input throws 500 with " ".