### PR TITLE
ci: don't run ecr-push for Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,7 +365,7 @@ jobs:
           retention-days: 2
 
   ecr-push:
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
     needs:
       - dockerize
       - service


### PR DESCRIPTION
Dependabot has no access to repository secrets, so AWS_ROLE is empty and the ecr-push job fails when configuring AWS credentials. Dependabot PRs should only build and test, never push images to ECR. Gate ecr-push on the actor like the other deploy-related steps already are.