### PR TITLE
ci(owasp): use only nightly NVD cache in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,7 @@ jobs:
         shell: bash
         run: |
           docker run --rm \
+              -e CI=true \
               -e NVD_API_KEY=${{ secrets.NVD_API_KEY }} \
               -e OSS_INDEX_USERNAME=${{ secrets.OSS_INDEX_USERNAME }} -e OSS_INDEX_PASSWORD=${{ secrets.OSS_INDEX_PASSWORD }} \
               -v $(pwd)/dependency-check-data:/root/.gradle/dependency-check-data \

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -272,6 +272,10 @@ tasks {
 
     dependencyCheck {
         failBuildOnCVSS = 0.0f
+        // In CI, use only the prebuilt nightly NVD cache mounted by owasp-cache-get
+        // and never fetch updates at analyze time. Locally keep autoUpdate on so a
+        // dev run can populate/refresh its own database.
+        autoUpdate = System.getenv("CI") != "true"
         analyzers.apply {
             assemblyEnabled = false
             nodeAuditEnabled = false


### PR DESCRIPTION
Set dependencyCheck autoUpdate=false when CI=true so dependencyCheckAnalyze relies solely on the prebuilt nightly cache mounted by owasp-cache-get and performs no NVD/aux-feed downloads at analyze time. Pass CI=true into the owasp docker container so the gated value reaches Gradle inside it. Local runs (CI unset) keep autoUpdate on to populate/refresh their own database.